### PR TITLE
fix: end-of-frame detection.

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,2 +1,21 @@
 pub mod encoder;
 pub mod decoder;
+
+
+#[test]
+fn test_end_of_frame() {
+    use std::io::{Read, Write};
+
+    let mut enc = encoder::Encoder::new(Vec::new(), 1).unwrap();
+    enc.write_all(b"foo").unwrap();
+    let mut compressed = enc.finish().unwrap();
+
+    // Add footer/whatever to underlying storage.
+    compressed.push(0);
+
+    // Drain zstd stream until end-of-frame.
+    let mut dec = decoder::Decoder::new(&compressed[..]).unwrap();
+    let mut buf = Vec::new();
+    dec.read_to_end(&mut buf).unwrap();
+    assert_eq!(&buf, b"foo");
+}


### PR DESCRIPTION
Do not suppose end-of-frame is aligned with storage's end-of-file.
Handy when zstd frames are part of larger streams, used to return
some puzzling "Context should be init first" error.

Zstd natively recognizes frame termination and signal the situation
through the special `0` value of the returned variant:
"ZBUFF_decompressContinue returns either a hint to preferred nb
of bytes to use as input for next function call or 0 when a frame
is completely decoded, or an error code, which can be tested using
ZBUFF_isError()".

Closes #3.