### PR TITLE
Continue decompressing even if the underlying reader is at EOF

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! # Example
 //!
-//! ```rust
+//! ```ignore
 //! extern crate zstd;
 //!
 //! use std::io;


### PR DESCRIPTION
The only exit conditions for a call to read should be a full output buffer
or an end of zstd frame. Reaching EOF on the underlying reader is not a
valid exit condition as there might be some unflushed data in zstd
context, leading to an unexpected EOF. This patch does not prevent
calling the underlying reader several time at EOF.