### PR TITLE
encoder: avoid returning ErrorKind::Interrupted

### DIFF
--- a/src/stream/encoder.rs
+++ b/src/stream/encoder.rs
@@ -272,13 +272,8 @@ impl<W: Write> Write for Encoder<W> {
             panic!("write called after try_finish attempted");
         }
 
-        if self.offset < self.buffer.len() {
-            // If we still had some things to write, do it first.
-            self.offset += self.writer.write(&self.buffer[self.offset..])?;
-            // Maybe next time!
-            return Err(io::Error::new(io::ErrorKind::Interrupted,
-                                      "Internal buffer full"));
-        }
+        // Write any data pending in `self.buffer`.
+        self.write_from_offset()?;
 
         // If we get to here, `self.buffer` can safely be discarded.
 


### PR DESCRIPTION
While `Interrupted` is theoretically a valid thing to return here, many
consumers deal poorly with it. It's much easier both for us and for consumers
to just loop until the internal buffer has been completely written out.

Other encoders like `bzip2-rs` and `flate2-rs` do the same thing.