### PR TITLE
proposal for AsyncRead/AsyncWrite implementation

### DIFF
--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -249,7 +249,7 @@ impl<R: Read> Decoder<R> {
 
 impl<R: Read> Read for Decoder<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        
+
         let mut in_buffer = zstd_sys::ZSTD_inBuffer {
             src: self.buffer.as_ptr() as *const c_void,
             size: self.buffer.len(),

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -3,6 +3,10 @@ use parse_code;
 use std::io::{self, Read};
 use zstd_sys;
 
+#[cfg(feature = "tokio")]
+use tokio_io::AsyncRead;
+
+
 struct DecoderContext {
     s: *mut zstd_sys::ZSTD_DStream,
 }
@@ -191,5 +195,12 @@ impl<R: Read> Read for Decoder<R> {
         }
         self.offset = in_buffer.pos;
         Ok(out_buffer.pos)
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl<R: AsyncRead> AsyncRead for Decoder<R> {
+    unsafe fn prepare_uninitialized_buffer(&self, _buf: &mut [u8]) -> bool {
+        false
     }
 }

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -216,7 +216,7 @@ impl<R: Read> Decoder<R> {
             }
         }
 
-        return Ok(false);
+        Ok(false)
     }
 
     /// This function handles Active state in the read operation - main read loop.
@@ -260,7 +260,7 @@ impl<R: Read> Decoder<R> {
                 return Ok(true);
             }
         }
-        return Ok(true);
+        Ok(true)
     }
 }
 

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -23,10 +23,18 @@ impl Drop for DecoderContext {
     }
 }
 
+// Extra bit of information that is stored along RefillBuffer state.
+// It describes the context in which refill was requested.
 #[derive(PartialEq, Copy, Clone)]
 enum RefillBufferHint {
+    // refill was requested during regular read operation,
+    // no extra actions are required
     None,
+    // we've reached the end of buffer and zstd wants more data
+    // in this circumstances refill must return more data, otherwise this is an error
     FailIfEmpty,
+    // we've reached the end of current frame,
+    // if refill brings more data we'll start new frame and complete reading otherwise
     EndOfFrame,
 }
 

--- a/src/stream/encoder.rs
+++ b/src/stream/encoder.rs
@@ -347,6 +347,33 @@ mod tests {
     use stream::decode_all;
     use stream::tests::WritePartial;
 
+    #[cfg(feature = "tokio")]
+    mod async_tests {
+        use std::io::{Cursor, Result};
+        use tokio_io::{AsyncWrite, AsyncRead, io};
+        use futures::Future;
+
+        #[test]
+        fn test_async_write() {
+            use stream::decode_all;
+
+            let source = "abc".repeat(10).into_bytes();
+            let writer = test_async_write_worker(&source[..], Cursor::new(Vec::new())).unwrap();
+            let encoded_output = writer.into_inner();
+            let decoded = decode_all(&encoded_output[..]).unwrap();
+            assert_eq!(source, &decoded[..]);
+        }
+
+        fn test_async_write_worker<R: AsyncRead, W: AsyncWrite>(r: R, w: W) -> Result<W> {
+            use super::Encoder;
+
+            let encoder = Encoder::new(w, 1).unwrap();
+            let (_, _, encoder) = try!(io::copy(r, encoder).wait());
+            let w = try!(encoder.finish());
+            Ok(w)
+        }
+    }
+
     /// Test that flush after a partial write works successfully without
     /// corrupting the frame. This test is in this module because it checks
     /// internal implementation details.


### PR DESCRIPTION
This PR is based on [async](https://github.com/gyscos/zstd-rs/issues/26) branch in this repo. 

- [x] - added implementation of `AsyncRead` to `Decoder`
- [x] - added tests for `AsyncRead` and `AsyncWrite`
- [x] - updated implementation of `read` to make sure that `ErrorKind::WouldBlock` is handled correctly

~~NOTE: we should probably add helpers to handle `ErrorKind::WouldBlock` in other methods besides `read` and `write` - i.e. in case of encoder `ErrorKind::WouldBlock` can be returned from `finish`.~~


// cc @sid0 