### PR TITLE
use partial-io for I/O tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 clap = "2.6.0"
+partial-io = "^0.2.1"
 
 [features]
 default = ["legacy"]

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -63,11 +63,8 @@ pub fn from_continuous(sample_data: &[u8], sample_sizes: &[usize],
 pub fn from_samples<S: AsRef<[u8]>>(samples: &[S], max_size: usize)
                                     -> io::Result<Vec<u8>> {
     // Copy every sample to a big chunk of memory
-    let data: Vec<_> = samples
-        .iter()
-        .flat_map(|s| s.as_ref())
-        .cloned()
-        .collect();
+    let data: Vec<_> =
+        samples.iter().flat_map(|s| s.as_ref()).cloned().collect();
     let sizes: Vec<_> = samples.iter().map(|s| s.as_ref().len()).collect();
 
     from_continuous(&data, &sizes, max_size)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,11 @@
 #![deny(missing_docs)]
 extern crate libc;
 
+#[cfg(test)]
+extern crate partial_io;
+
 extern crate zstd_sys;
+
 
 pub mod stream;
 pub mod block;

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -302,20 +302,19 @@ impl<R: Read> Read for Decoder<R> {
         };
 
         loop {
-            let should_stop =
-                match self.state {
-                    DecoderState::Completed => {
-                        return Ok(0);
-                    }
-                    DecoderState::RefillBuffer(action) => {
+            let should_stop = match self.state {
+                DecoderState::Completed => {
+                    return Ok(0);
+                }
+                DecoderState::RefillBuffer(action) => {
                         self.handle_refill(action,
                                            &mut in_buffer,
                                            &mut out_buffer)?
                     }
-                    DecoderState::Active => {
-                        self.handle_active(&mut in_buffer, &mut out_buffer)?
-                    }
-                };
+                DecoderState::Active => {
+                    self.handle_active(&mut in_buffer, &mut out_buffer)?
+                }
+            };
             if should_stop {
                 break;
             }

--- a/src/stream/encoder.rs
+++ b/src/stream/encoder.rs
@@ -354,8 +354,9 @@ impl<W: AsyncWrite> AsyncWrite for Encoder<W> {
 #[cfg(test)]
 mod tests {
     use super::Encoder;
+    use partial_io::{PartialOp, PartialWrite};
+    use std::iter;
     use stream::decode_all;
-    use stream::tests::WritePartial;
 
     /// Test that flush after a partial write works successfully without
     /// corrupting the frame. This test is in this module because it checks
@@ -385,11 +386,11 @@ mod tests {
         assert_eq!(&decode_all(&buf[..]).unwrap(), &input);
     }
 
-    fn setup_partial_write() -> (Vec<u8>, Encoder<WritePartial>) {
+    fn setup_partial_write() -> (Vec<u8>, Encoder<PartialWrite<Vec<u8>>>) {
         use std::io::Write;
 
-        let mut buf = WritePartial::new();
-        buf.accept(Some(1));
+        let buf = PartialWrite::new(Vec::new(),
+                                    iter::repeat(PartialOp::Limited(1)));
         let mut z = Encoder::new(buf, 1).unwrap();
 
         // Fill in enough data to make sure the buffer gets written out.


### PR DESCRIPTION
We recently released the `partial-io` crate, which adds convenience wrappers
for partial reads and writes.  It's basically a more formal version of a couple
of helpers we already had.

`partial-io` also supports `quickcheck` for random test cases. That could
eventually be used as well, as in e.g.
https://github.com/alexcrichton/bzip2-rs/pull/20.

What do you think?