### PR TITLE
stream: switch to randomized testing with partial-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ futures = { version = "0.1", optional = true }
 [dev-dependencies]
 clap = "2.6.0"
 partial-io = "^0.2.1"
+quickcheck = "0.4"
 
 [features]
 default = ["legacy"]
 legacy = ["zstd-sys/legacy"]
 bindgen = ["zstd-sys/bindgen"]
-tokio = ["tokio-io", "futures"]
+tokio = ["tokio-io", "futures", "partial-io/quickcheck", "partial-io/tokio"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,8 @@ pub mod dict;
 extern crate tokio_io;
 #[cfg(feature = "tokio")]
 extern crate futures;
-
+#[cfg(all(test, feature = "tokio"))]
+extern crate quickcheck;
 
 use std::ffi::CStr;
 


### PR DESCRIPTION
This is pretty straightforward and a good demonstration that zstd
doesn't break down when confronted with transient errors.