### PR TITLE
travis: add CI for the optional tokio feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,16 @@ rust:
     - stable
     - beta
     - nightly
+env:
+    matrix:
+    # Combinations of optional features
+    - FEATURES=''
+    - FEATURES='tokio'
+
 matrix:
   allow_failures:
     - rust: nightly
 
+script:
+    - cargo build --verbose --features "$FEATURES"
+    - cargo test --verbose --features "$FEATURES"


### PR DESCRIPTION
This makes sure the project builds both with tokio and without.