### PR TITLE
Make zstd contexts and streams support Send, and dicts support Send + Sync

### DIFF
--- a/src/block/compressor.rs
+++ b/src/block/compressor.rs
@@ -62,3 +62,9 @@ impl Compressor {
         Ok(buffer)
     }
 }
+
+fn _assert_traits() {
+    fn _assert_send<T: Send>(_: T) {}
+
+    _assert_send(Compressor::new());
+}

--- a/src/block/decompressor.rs
+++ b/src/block/decompressor.rs
@@ -57,3 +57,9 @@ impl Decompressor {
         Ok(buffer)
     }
 }
+
+fn _assert_traits() {
+    fn _assert_send<T: Send>(_: T) {}
+
+    _assert_send(Decompressor::new());
+}

--- a/src/stream/decoder.rs
+++ b/src/stream/decoder.rs
@@ -295,6 +295,14 @@ impl<R: AsyncRead> AsyncRead for Decoder<R> {
     }
 }
 
+fn _assert_traits() {
+    use std::io::Cursor;
+
+    fn _assert_send<T: Send>(_: T) {}
+
+    _assert_send(Decoder::new(Cursor::new(Vec::new())));
+}
+
 #[cfg(test)]
 #[cfg(feature = "tokio")]
 mod async_tests {

--- a/src/stream/encoder.rs
+++ b/src/stream/encoder.rs
@@ -347,6 +347,12 @@ impl<W: AsyncWrite> AsyncWrite for Encoder<W> {
     }
 }
 
+fn _assert_traits() {
+    fn _assert_send<T: Send>(_: T) {}
+
+    _assert_send(Encoder::new(Vec::new(), 1));
+}
+
 #[cfg(test)]
 mod tests {
     use super::Encoder;

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -159,6 +159,9 @@ impl Drop for CCtx {
     }
 }
 
+unsafe impl Send for CCtx {}
+// CCtx can't be shared across threads, so it does not implement Sync.
+
 pub fn get_error_name(code: usize) -> &'static str {
     unsafe {
         // We are getting a *const char from zstd
@@ -207,6 +210,9 @@ impl Drop for DCtx {
         }
     }
 }
+
+unsafe impl Send for DCtx {}
+// DCtx can't be shared across threads, so it does not implement Sync.
 
 /// `ZSTD_decompressDCtx()`
 ///
@@ -296,6 +302,9 @@ impl<'a> Drop for CDict<'a> {
     }
 }
 
+unsafe impl<'a> Send for CDict<'a> {}
+unsafe impl<'a> Sync for CDict<'a> {}
+
 /// `ZSTD_compress_usingCDict()`
 ///
 /// Compression using a digested Dictionary.
@@ -342,6 +351,9 @@ impl<'a> Drop for DDict<'a> {
     }
 }
 
+unsafe impl<'a> Send for DDict<'a> {}
+unsafe impl<'a> Sync for DDict<'a> {}
+
 /// `ZSTD_decompress_usingDDict()`
 ///
 /// Decompression using a digested Dictionary.
@@ -379,6 +391,10 @@ impl Drop for CStream {
         }
     }
 }
+
+unsafe impl Send for CStream {}
+// CStream can't be shared across threads, so it does not implement Sync.
+
 pub fn init_cstream(zcs: &mut CStream, compression_level: i32) -> usize {
     unsafe { zstd_sys::ZSTD_initCStream(zcs.0, compression_level) }
 }
@@ -522,6 +538,9 @@ impl Drop for DStream {
         }
     }
 }
+
+unsafe impl Send for DStream {}
+// DStream can't be shared across threads, so it does not implement Sync.
 
 pub fn init_dstream(zds: &mut DStream) -> usize {
     unsafe { zstd_sys::ZSTD_initDStream(zds.0) }


### PR DESCRIPTION
According to @Cyan4973, streams and contexts support `Send`, and dicts
support both `Send` and `Sync`.

Also include compile-time checks to make sure the higher-level stream and block APIs support `Send`.