### PR TITLE
Update `bindgen` dependency to 0.31.X

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -12,7 +12,7 @@ readme = "Readme.md"
 links = "zstd"
 
 [build-dependencies]
-bindgen = { version = "0.30", optional = true }
+bindgen = { version = "0.31", optional = true }
 gcc = "0.3.51"
 glob = "0.2.11"
 

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -12,8 +12,7 @@ fn generate_bindings() {
 
     let bindings = bindgen::Builder::default()
         .header("zstd.h")
-        .generate_comments(false) //< remove this when it works
-        .hide_type("max_align_t")
+        .blacklist_type("max_align_t")
         .use_core()
         .ctypes_prefix("::libc")
         .clang_arg("-Izstd/lib")


### PR DESCRIPTION
The `hide_type` method has been renamed to `blacklist_type` to match the CLI flag.

The bindings seem to work just fine with `generate_comments` for me now.