### PR TITLE
make it possible to build `zstd` without `zstd-safe/std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "Readme.md"
 travis-ci = { repository = "gyscos/zstd-rs" }
 
 [dependencies]
-zstd-safe = { path="zstd-safe", version = "1.4.5", default-features = false, features=["std"] }
+zstd-safe = { path="zstd-safe", version = "1.4.5", default-features = false }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 
@@ -27,7 +27,8 @@ humansize = "1.0"
 walkdir = "2.2.5"
 
 [features]
-default = ["legacy"]
+default = ["legacy", "std"]
 legacy = ["zstd-safe/legacy"]
 bindgen = ["zstd-safe/bindgen"]
+std = ["zstd-safe/std"]
 tokio = ["tokio-io", "futures", "partial-io/quickcheck", "partial-io/tokio"]


### PR DESCRIPTION
A [build][hpk-build] started to fail with zstd `0.4.21+zstd.1.3.7` on `i686-pc-windows-gnu` and i had to pin zstd to the previous version because of a bindgen issue and the forced `zstd-safe/std` feature.
Everything works fine for `i686-pc-windows-*` without the bindgen feature.

I haven't tried windows on travis yet. so, here the [build jobs][zstd-build] for zstd on appveyor.
- *-pc-windows-gnu builds without std 
- x86_64-pc-windows-gnu builds with std
- i686-pc-windows-gnu fails with std

[hpk-build]: https://ci.appveyor.com/project/nickelc/hpk/builds/19811691/job/ogt35xy4gn0qkxm4
[zstd-build]: https://ci.appveyor.com/project/nickelc/zstd-rs/builds/19827928