### PR TITLE
Make zstd_safe really safe

### DIFF
--- a/src/block/compressor.rs
+++ b/src/block/compressor.rs
@@ -1,4 +1,4 @@
-use parse_code;
+use map_error_code;
 
 use std::io;
 use zstd_safe;
@@ -39,16 +39,13 @@ impl Compressor {
         destination: &mut [u8],
         level: i32,
     ) -> io::Result<usize> {
-        let code = {
             zstd_safe::compress_using_dict(
                 &mut self.context,
                 destination,
                 source,
                 &self.dict[..],
                 level,
-            )
-        };
-        parse_code(code)
+            ).map_err(map_error_code)
     }
 
     /// Compresses a block of data and returns the compressed result.

--- a/src/block/decompressor.rs
+++ b/src/block/decompressor.rs
@@ -1,4 +1,4 @@
-use parse_code;
+use map_error_code;
 
 use std::io;
 use zstd_safe;
@@ -35,15 +35,12 @@ impl Decompressor {
         source: &[u8],
         destination: &mut [u8],
     ) -> io::Result<usize> {
-        let code = {
-            zstd_safe::decompress_using_dict(
-                &mut self.context,
-                destination,
-                source,
-                &self.dict,
-            )
-        };
-        parse_code(code)
+        zstd_safe::decompress_using_dict(
+            &mut self.context,
+            destination,
+            source,
+            &self.dict,
+        ).map_err(map_error_code)
     }
 
     /// Decompress a block of data, and return the result in a `Vec<u8>`.

--- a/src/dict.rs
+++ b/src/dict.rs
@@ -14,7 +14,7 @@
 //! [`Encoder::with_dictionary`]: ../struct.Encoder.html#method.with_dictionary
 //! [`Decoder::with_dictionary`]: ../struct.Decoder.html#method.with_dictionary
 
-use parse_code;
+use map_error_code;
 use std::fs;
 
 use std::io::{self, Read};
@@ -81,11 +81,11 @@ pub fn from_continuous(
     let mut result = Vec::with_capacity(max_size);
     unsafe {
         result.set_len(max_size);
-        let written = parse_code(zstd_safe::train_from_buffer(
+        let written = zstd_safe::train_from_buffer(
             &mut result,
             sample_data,
             sample_sizes,
-        ))?;
+        ).map_err(map_error_code)?;
         result.set_len(written);
     }
     Ok(result)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,18 +49,10 @@ pub use zstd_safe::CLEVEL_DEFAULT as DEFAULT_COMPRESSION_LEVEL;
 #[doc(no_inline)]
 pub use stream::{decode_all, encode_all, Decoder, Encoder};
 
-/// Parse the result code
-///
-/// Returns the number of bytes written if the code represents success,
-/// or the error message otherwise.
-fn parse_code(code: usize) -> io::Result<usize> {
-    if zstd_safe::is_error(code) == 0 {
-        Ok(code)
-    } else {
-        let msg = zstd_safe::get_error_name(code);
-        let error = io::Error::new(io::ErrorKind::Other, msg.to_string());
-        Err(error)
-    }
+/// Returns the error message as io::Error based on error_code.
+fn map_error_code(code: usize) -> io::Error {
+    let msg = zstd_safe::get_error_name(code);
+    io::Error::new(io::ErrorKind::Other, msg.to_string())
 }
 
 // Some helper functions to write full-cycle tests.

--- a/src/stream/read/tests.rs
+++ b/src/stream/read/tests.rs
@@ -2,6 +2,16 @@ use std::io::Read;
 use stream::read::{Decoder, Encoder};
 
 #[test]
+fn test_error_handling() {
+    let invalid_input = b"Abcdefghabcdefgh";
+
+    let mut decoder = Decoder::new(&invalid_input[..]).unwrap();
+    let output = decoder.read_to_end(&mut Vec::new());
+
+    assert_eq!(output.is_err(), true);
+}
+
+#[test]
 fn test_cycle() {
     let input = b"Abcdefghabcdefgh";
 


### PR DESCRIPTION
One part of being safe is to check error codes. But current implementation always return usize and return code must be checked in zstd-rs crate. This commit changes the behaviour that zstd-safe functions returns SafeResult.