### PR TITLE
Check if zstd submodule is cloned

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -97,6 +97,10 @@ fn compile_zstd() {
 
 fn main() {
     // println!("cargo:rustc-link-lib=zstd");
+    
+    if !PathBuf::from("zstd/lib").exists() {
+        panic!("Folder 'zstd/lib' does not exists. Maybe you forget clone 'zstd' submodule?");
+    }
 
     compile_zstd();
     generate_bindings();


### PR DESCRIPTION
Because now without submodule, the not clear error message is showed:

```
thread 'main' panicked at '

Internal error occurred: Command "ar" "crs" "/Users/xxx/zstd-rs/target/debug/build/zstd-sys-49975c690f361f7a/out/libzstd.a" with args "ar" did not execute successfully (status code exit code: 1).
```