### PR TITLE
Add pkg-config feature to use pre-installed libzstd

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -26,6 +26,10 @@ glob = "0.2.11"
 optional = true
 version = "0.46.0"
 
+[build-dependencies.pkg-config]
+optional = true
+version = "0.3"
+
 [build-dependencies.cc]
 version = "1.0.28"
 features = ["parallel"]
@@ -35,6 +39,7 @@ libc = "0.2.45"
 
 [features]
 default = ["legacy"]
+non-cargo = []
 legacy = []
 zstdmt = []
 std = ["bindgen"]

--- a/zstd-safe/zstd-sys/zstd.h
+++ b/zstd-safe/zstd-sys/zstd.h
@@ -1,6 +1,12 @@
+#ifdef PKG_CONFIG
+/* Just use installed headers */
+#include <zstd.h>
+#include <zdict.h>
+#else
 #include "zstd/lib/zstd.h"
 #include "zstd/lib/dictBuilder/zdict.h"
 #include "zstd/lib/compress/zstdmt_compress.h"
+#endif
 
 /* This file is used to generate bindings for both headers.
  * Just run the following command to generate the bindings:


### PR DESCRIPTION
This will use pkg-config to locate the existing library. Use in
combination with bindgen to generate a binding from that header.

The `non-cargo` feature will suppress emitting metadata for cargo
(for cases where cargo isn't doing the final link).

Addresses issue https://github.com/gyscos/zstd-rs/issues/58