### PR TITLE
Copy public zstd_errors.h into output directory

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -119,6 +119,11 @@ fn compile_zstd() {
     fs::create_dir_all(&include).unwrap();
     fs::copy(src.join("zstd.h"), include.join("zstd.h")).unwrap();
     fs::copy(
+        src.join("common").join("zstd_errors.h"),
+        include.join("zstd_errors.h"),
+    )
+    .unwrap();
+    fs::copy(
         src.join("dictBuilder").join("zdict.h"),
         include.join("zdict.h"),
     )


### PR DESCRIPTION
The common/zstd_errors.h header file is also part of the public
interface of the zstd library. Copy it into the output directory, like
the upstream build system does [0], so that downstream dependencies can
find it.

[0]: https://github.com/facebook/zstd/blob/0f9866add2df8e824c96f67fc49a7d5b69ad3317/lib/Makefile#L275