### PR TITLE
Add a links attribute to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.5.1+zstd.1.4.4"
 exclude = ["assets/**"]
 readme = "Readme.md"
 edition = "2018"
+links = "zstd"
 
 [badges]
 travis-ci = { repository = "gyscos/zstd-rs" }


### PR DESCRIPTION
This is "cleaner", and helps if multiple dependencies rely on multiple different versions of `zstd-sys`:
https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key