### PR TITLE
Export includes paths as cargo metadata

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -20,6 +20,7 @@ version = "1.4.15+zstd.1.4.4"
 
 [build-dependencies]
 glob = "0.3"
+itertools = "0.8.1"
 
 [build-dependencies.bindgen]
 optional = true


### PR DESCRIPTION
Depending projects will be able to use this by looking into the env
varilabe `DEP_ZSTD_INCLUDE`. This variable will contain a `;` seperated
list of include paths.