### PR TITLE
fix: Set ZSTD_MULTITHREAD when built with zstdmt

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -76,6 +76,14 @@ fn set_pthread(config: &mut cc::Build) {
 #[cfg(not(feature = "zstdmt"))]
 fn set_pthread(_config: &mut cc::Build) {}
 
+#[cfg(feature = "zstdmt")]
+fn enable_threading(config: &mut cc::Build) {
+    config.define("ZSTD_MULTITHREAD", Some(""));
+}
+
+#[cfg(not(feature = "zstdmt"))]
+fn enable_threading(_config: &mut cc::Build) {}
+
 fn compile_zstd() {
     let mut config = cc::Build::new();
 
@@ -113,6 +121,7 @@ fn compile_zstd() {
 
     set_pthread(&mut config);
     set_legacy(&mut config);
+    enable_threading(&mut config);
 
     // Compile!
     config.compile("libzstd.a");


### PR DESCRIPTION
Advanced features like multithreading are only available when libzstd
is statically linked per documentation. pkg-config is not very good
for static linking. That means users have to rely on this crate to build it
correctly.

Current `build.rs` is not passing `ZSTD_MULTITHREAD` flag to cc and
because of that resulting library built without multithreading support.

Resolves: #64