### PR TITLE
using of target_arch/_os to detect, if the platform has a libc

### DIFF
--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Alexandre Bury <alexandre.bury@gmail.com>"]
 name = "zstd-safe"
+build = "build.rs"
 version = "2.0.5+zstd.1.4.5"
 description = "Safe low-level bindings for the zstd compression library."
 keywords = ["zstd", "zstandard", "compression"]

--- a/zstd-safe/build.rs
+++ b/zstd-safe/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_arch == "wasm32" || target_os == "hermit" { 
+        println!("cargo:rustc-cfg=feature=\"std\"");
+    }
+}

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -21,7 +21,7 @@
 extern crate libc;
 extern crate zstd_sys;
 
-#[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
+#[cfg(feature = "std")]
 extern crate std;
 
 #[cfg(test)]
@@ -33,10 +33,10 @@ pub use zstd_sys::ZSTD_strategy as Strategy;
 /// Reset directive.
 pub use zstd_sys::ZSTD_ResetDirective as ResetDirective;
 
-#[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
+#[cfg(feature = "std")]
 use std::os::raw::{c_char, c_int, c_ulonglong, c_void};
 
-#[cfg(not(any(target_arch = "wasm32", target_os = "hermit")))]
+#[cfg(not(feature = "std"))]
 use libc::{c_char, c_int, c_ulonglong, c_void};
 
 use core::marker::PhantomData;
@@ -211,7 +211,7 @@ unsafe impl<'a> Send for CCtx<'a> {}
 // CCtx can't be shared across threads, so it does not implement Sync.
 
 unsafe fn c_char_to_str(text: *const c_char) -> &'static str {
-    #[cfg(not(any(target_arch = "wasm32", target_os = "hermit")))]
+    #[cfg(not(feature = "std"))]
     {
         // To be safe, we need to compute right now its length
         let len = libc::strlen(text);
@@ -222,7 +222,7 @@ unsafe fn c_char_to_str(text: *const c_char) -> &'static str {
         str::from_utf8(slice).expect("bad error message from zstd")
     }
 
-    #[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
+    #[cfg(feature = "std")]
     {
         std::ffi::CStr::from_ptr(text)
             .to_str()

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -21,7 +21,7 @@
 extern crate libc;
 extern crate zstd_sys;
 
-#[cfg(feature = "std")]
+#[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
 extern crate std;
 
 #[cfg(test)]
@@ -33,10 +33,10 @@ pub use zstd_sys::ZSTD_strategy as Strategy;
 /// Reset directive.
 pub use zstd_sys::ZSTD_ResetDirective as ResetDirective;
 
-#[cfg(feature = "std")]
+#[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
 use std::os::raw::{c_char, c_int, c_ulonglong, c_void};
 
-#[cfg(not(feature = "std"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "hermit")))]
 use libc::{c_char, c_int, c_ulonglong, c_void};
 
 use core::marker::PhantomData;
@@ -211,7 +211,7 @@ unsafe impl<'a> Send for CCtx<'a> {}
 // CCtx can't be shared across threads, so it does not implement Sync.
 
 unsafe fn c_char_to_str(text: *const c_char) -> &'static str {
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(any(target_arch = "wasm32", target_os = "hermit")))]
     {
         // To be safe, we need to compute right now its length
         let len = libc::strlen(text);
@@ -222,7 +222,7 @@ unsafe fn c_char_to_str(text: *const c_char) -> &'static str {
         str::from_utf8(slice).expect("bad error message from zstd")
     }
 
-    #[cfg(feature = "std")]
+    #[cfg(any(target_arch = "wasm32", target_os = "hermit"))]
     {
         std::ffi::CStr::from_ptr(text)
             .to_str()

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -147,6 +147,13 @@ fn compile_zstd() {
 }
 
 fn main() {
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+
+    if target_arch == "wasm32" || target_os == "hermit" {
+        println!("cargo:rustc-cfg=feature=\"std\"");
+    }
+
     // println!("cargo:rustc-link-lib=zstd");
     let (defs, headerpaths) = if cfg!(feature = "pkg-config") {
         pkg_config()


### PR DESCRIPTION
Beside wasm32 also RustHermit doen't have a classical C library.
Using of target_arch/_os to detect these platforms. It simplifies
the usage of this crate.