### PR TITLE
Update bindgen to 0.56

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -27,7 +27,7 @@ itertools = "0.9"
 
 [build-dependencies.bindgen]
 optional = true
-version = "0.54"
+version = "0.56"
 
 [build-dependencies.pkg-config]
 optional = true


### PR DESCRIPTION
This bindgen update does not require other code changes, as far as I can tell. A local build of zstd-sys with bindgen 0.56 was successful.