### PR TITLE
add debug feature to enable zstd debug logs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ default = ["legacy"]
 tokio = ["tokio-io", "futures"]
 
 bindgen = ["zstd-safe/bindgen"]
+debug = ["zstd-safe/debug"]
 legacy = ["zstd-safe/legacy"]
 pkg-config = ["zstd-safe/pkg-config"]
 wasm = ["zstd-safe/std"] # To compile on wasm we need to avoid using libc

--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -21,6 +21,7 @@ libc = "0.2.21"
 default = ["legacy"]
 
 bindgen = ["zstd-sys/bindgen"]
+debug = ["zstd-sys/debug"]
 experimental = ["zstd-sys/experimental"]
 legacy = ["zstd-sys/legacy"]
 pkg-config = ["zstd-sys/pkg-config"]

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -121,6 +121,21 @@ fn compile_zstd() {
     config.define("ZDICTLIB_VISIBILITY", Some(""));
     config.define("ZSTDERRORLIB_VISIBILITY", Some(""));
 
+
+    // https://github.com/facebook/zstd/blob/d69d08ed6c83563b57d98132e1e3f2487880781e/lib/common/debug.h#L60
+    /* recommended values for DEBUGLEVEL :
+    * 0 : release mode, no debug, all run-time checks disabled
+    * 1 : enables assert() only, no display
+    * 2 : reserved, for currently active debug path
+    * 3 : events once per object lifetime (CCtx, CDict, etc.)
+    * 4 : events once per frame
+    * 5 : events once per block
+    * 6 : events once per sequence (verbose)
+    * 7+: events at every position (*very* verbose)
+    */
+    #[cfg(feature = "debug")]
+    config.define("DEBUGLEVEL", Some("5"));
+
     set_pthread(&mut config);
     set_legacy(&mut config);
     enable_threading(&mut config);


### PR DESCRIPTION
ZSTD sometimes doesn't output very helpful information by default. This adds a feature to enable debug logging from zstd.

before:
```
[2020-12-20T16:16:04Z DEBUG sqlite_zstd::dict_training] training dict of size 1503kB with 196608 samples of total size 150338kB (of 196608 samples seen)
Error: Training dictionary failed

Caused by:
    Error (generic)
```

what is happen??!!

after with features = ["debug"]:

```
[2020-12-20T16:16:04Z DEBUG sqlite_zstd::dict_training] training dict of size 1503kB with 196608 samples of total size 150338kB (of 196608 samples seen)
zstd/lib/dictBuilder/zdict.c: ZDICT_trainFromBuffer
Trying 5 different sets of parameters
d=8
Training on 147456 samples of total size 100940410
Testing on 49152 samples of total size 49397760
Computing frequencies
k=50
Breaking content into 30067 epochs of size 3357
zstd/lib/dictBuilder/zdict.c: ZDICT_finalizeDictionary
Failed to select dictionary
20%       k=537
Breaking content into 2799 epochs of size 36063
zstd/lib/dictBuilder/zdict.c: ZDICT_finalizeDictionary
Failed to select dictionary
40%       k=1024
Breaking content into 1468 epochs of size 68760
zstd/lib/dictBuilder/zdict.c: ZDICT_finalizeDictionary
Failed to select dictionary
60%       k=1511
Breaking content into 994 epochs of size 101549
zstd/lib/dictBuilder/zdict.c: ZDICT_finalizeDictionary
Failed to select dictionary
80%       k=1998
Breaking content into 752 epochs of size 134229
zstd/lib/dictBuilder/zdict.c: ZDICT_finalizeDictionary
Failed to select dictionary
Error: Training dictionary failed

Caused by:
    Error (generic)
```