### PR TITLE
Use decompression bound API to limit decompressor allocation

### DIFF
--- a/src/block/decompressor.rs
+++ b/src/block/decompressor.rs
@@ -1,5 +1,7 @@
 use crate::map_error_code;
 
+#[cfg(feature = "experimental")]
+use std::convert::TryInto;
 use std::io;
 use zstd_safe;
 
@@ -54,7 +56,7 @@ impl Decompressor {
         capacity: usize,
     ) -> io::Result<Vec<u8>> {
         let capacity =
-            self.upper_bound(data).unwrap_or(capacity).min(capacity);
+            Self::upper_bound(data).unwrap_or(capacity).min(capacity);
         let mut buffer = Vec::with_capacity(capacity);
         unsafe {
             buffer.set_len(capacity);
@@ -66,15 +68,16 @@ impl Decompressor {
 
     /// Get an upper bound on the decompressed size of data, if available
     ///
-    /// This can be used to pre-allocate enough capacity for [`decompress_to_buffer`]
-    /// and is used by [`decompress`] to ensure that it does not over-allocate if
+    /// This can be used to pre-allocate enough capacity for `decompress_to_buffer`
+    /// and is used by `decompress` to ensure that it does not over-allocate if
     /// you supply a large `capacity`.
     ///
-    /// Will return `None` if the upper bound cannot be determined
-    pub fn upper_bound(&self, _data: &[u8]) -> Option<usize> {
+    /// Will return `None` if the upper bound cannot be determined or is larger than `usize::MAX`
+    pub fn upper_bound(_data: &[u8]) -> Option<usize> {
         #[cfg(feature = "experimental")]
         {
-            zstd_safe::decompress_bound(_data)
+            let bound = zstd_safe::decompress_bound(_data).ok()?;
+            bound.try_into().ok()
         }
         #[cfg(not(feature = "experimental"))]
         {

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -1622,3 +1622,16 @@ pub fn decompress_block(dctx: &mut DCtx, dst: &mut [u8], src: &[u8]) -> usize {
 pub fn insert_block(dctx: &mut DCtx, block: &[u8]) -> usize {
     dctx.insert_block(block)
 }
+
+/// Wraps the `ZSTD_decompressBound` function
+#[cfg(feature = "experimental")]
+pub fn decompress_bound(data: &[u8]) -> Option<usize> {
+    let bound =
+        unsafe { zstd_sys::ZSTD_decompressBound(ptr_void(data), data.len()) }
+            as usize;
+    if is_error(bound) {
+        None
+    } else {
+        Some(bound)
+    }
+}

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -1625,13 +1625,12 @@ pub fn insert_block(dctx: &mut DCtx, block: &[u8]) -> usize {
 
 /// Wraps the `ZSTD_decompressBound` function
 #[cfg(feature = "experimental")]
-pub fn decompress_bound(data: &[u8]) -> Option<usize> {
+pub fn decompress_bound(data: &[u8]) -> Result<u64, ErrorCode> {
     let bound =
-        unsafe { zstd_sys::ZSTD_decompressBound(ptr_void(data), data.len()) }
-            as usize;
-    if is_error(bound) {
-        None
+        unsafe { zstd_sys::ZSTD_decompressBound(ptr_void(data), data.len()) };
+    if is_error(bound as usize) {
+        Err(bound as usize)
     } else {
-        Some(bound)
+        Ok(bound)
     }
 }

--- a/zstd-safe/src/tests.rs
+++ b/zstd-safe/src/tests.rs
@@ -123,3 +123,16 @@ fn test_checksum() {
     // The error message will complain about the checksum.
     assert!(err.contains("checksum"));
 }
+
+#[cfg(feature="experimental")]
+#[test]
+fn test_upper_bound() {
+    let mut buffer = std::vec![0u8; 256];
+
+    assert_eq!(zstd_safe::decompress_bound(&buffer), None);
+
+    let written = zstd_safe::compress(&mut buffer, INPUT, 3).unwrap();
+    let compressed = &buffer[..written];
+
+    assert_eq!(zstd_safe::decompress_bound(&compressed), Some(INPUT.len()));
+}

--- a/zstd-safe/src/tests.rs
+++ b/zstd-safe/src/tests.rs
@@ -129,10 +129,10 @@ fn test_checksum() {
 fn test_upper_bound() {
     let mut buffer = std::vec![0u8; 256];
 
-    assert_eq!(zstd_safe::decompress_bound(&buffer), None);
+    assert!(zstd_safe::decompress_bound(&buffer).is_err());
 
     let written = zstd_safe::compress(&mut buffer, INPUT, 3).unwrap();
     let compressed = &buffer[..written];
 
-    assert_eq!(zstd_safe::decompress_bound(&compressed), Some(INPUT.len()));
+    assert_eq!(zstd_safe::decompress_bound(&compressed), Ok(INPUT.len() as u64));
 }


### PR DESCRIPTION
There's an experimental API that gives us an upper limit on the space needed to decompress a given zstd compressed block. 

Expose this to users if the `experimental` feature is on and the block is valid, and use it in `decompress` to reduce the size of allocations if the C library promises that decompressed data is smaller than the capacity the user provided.

Without `experimental`, we always return `None` for the upper bound, which is treated by the `decompress` changes as "do not limit capacity".