### PR TITLE
Exclude unneeded files from the C repo when packaging

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -18,6 +18,14 @@ readme = "Readme.md"
 repository = "https://github.com/gyscos/zstd-rs"
 version = "1.5.0+zstd.1.4.9"
 
+exclude = [
+    "zstd",
+    "!zstd/LICENSE",
+    "!zstd/COPYING",
+    "!zstd/lib/**/**.h",
+    "!zstd/lib/**/**.c",
+]
+
 [package.metadata.docs.rs]
 features = ["experimental"]
 


### PR DESCRIPTION
I happened to be watching the output of a fresh fetch and noticed that zstd-sys was the largest crate that was downloaded at 1.9MiB and suspected it was due to including the entirety of the C lib's repo, which was indeed the case. This just excludes everything from that repo that isn't needed for actually compiling the lib, and the the LICENSE/COPYING file of course.

This makes the crate go from 1.9MiB to 632KiB, so a little less than 1/3 of the current size.