### PR TITLE
Support the new long-distance matcher

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -74,6 +74,18 @@ macro_rules! readwritecommon {
             )
         }
 
+        /// Enables or disables long-distance matching
+        pub fn long_distance_matching(
+            &mut self,
+            long_distance_matching: bool,
+        ) -> io::Result<()> {
+            self.$readwrite.operation_mut().set_parameter(
+                zstd_safe::CParameter::EnableLongDistanceMatching(
+                    long_distance_matching,
+                ),
+            )
+        }
+
         #[cfg(feature = "experimental")]
         /// Enables or disable the magic bytes at the beginning of each frame.
         ///


### PR DESCRIPTION
zstd 1.3.2 added a long-distance matcher
(https://github.com/facebook/zstd/releases/tag/v1.3.2); add a function
to set that parameter.