### PR TITLE
Fix the Decoder API sometimes not outputting all available data

### DIFF
--- a/src/stream/zio/reader.rs
+++ b/src/stream/zio/reader.rs
@@ -93,7 +93,7 @@ where
         loop {
             let (bytes_read, bytes_written) = {
                 // Start with a fresh pool of un-processed data.
-                // This is the only line that can return an interuption error.
+                // This is the only line that can return an interruption error.
                 let input = fill_buf(&mut self.reader)?;
 
                 // println!("{:?}", input);

--- a/src/stream/zio/reader.rs
+++ b/src/stream/zio/reader.rs
@@ -90,17 +90,19 @@ where
         }
 
         // Keep trying until _something_ has been written.
+        let mut first = true;
         loop {
             let (bytes_read, bytes_written) = {
                 // Start with a fresh pool of un-processed data.
                 // This is the only line that can return an interruption error.
-                let input = fill_buf(&mut self.reader)?;
+                let input = if first { b"" } else { fill_buf(&mut self.reader)? };
 
                 // println!("{:?}", input);
 
                 // It's possible we don't have any new data to read.
                 // (In this case we may still have zstd's own buffer to clear.)
-                let eof = input.is_empty();
+                let eof = !first && input.is_empty();
+                first = false;
 
                 let mut src = InBuffer::around(input);
                 let mut dst = OutBuffer::around(buf);


### PR DESCRIPTION
This is done by first asking zstd for more data, before trying to read
more compressed bytes from the data source.

An alternative would be the
[`BufReader::buffer`](https://doc.rust-lang.org/std/io/struct.BufReader.html#method.buffer)
function, but that is not available because we only have a type that
satisfies `BufRead` in this context.

I tested this with my TCP connection and it solved my problem.

Fixes #119.

I haven't tested this for performance regressions.