### PR TITLE
Generic closures for AutoFinishEncoder for deriving autotraits

### DIFF
--- a/src/stream/write/tests.rs
+++ b/src/stream/write/tests.rs
@@ -54,6 +54,16 @@ fn test_partial_write_finish() {
     assert_eq!(&decode_all(&buf[..]).unwrap(), &input);
 }
 
+#[test]
+fn send_autoencoder() {
+    let input = vec![b'b'; 128 * 1024];
+    let z = setup_partial_write(&input);
+    let auto = z.on_finish(|_| {});
+
+    fn assert_is_send<T: Send>(_: T) {}
+    assert_is_send(auto);
+}
+
 fn setup_partial_write(input_data: &[u8]) -> Encoder<PartialWrite<Vec<u8>>> {
     let buf =
         PartialWrite::new(Vec::new(), iter::repeat(PartialOp::Limited(1)));


### PR DESCRIPTION
I'm not sure, but still tried to make it API non-breaking change.

The patch uses generic for `AutoFinishEncoder` closure, so it will be possible to derive marker traits for the type itself. In particularly `Send` trait, as presented in the test.