### PR TITLE
Include wasm-shim files in cargo package

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -25,12 +25,12 @@ include = [
     "/LICENSE",
     "/*.*",
     "/src/",
+    "/wasm-shim/**/*.h",
     "/zstd/LICENSE",
     "/zstd/COPYING",
     "/zstd/lib/**/*.c",
     "/zstd/lib/**/*.h",
     "/zstd/lib/**/*.S",
-    "/wasm-shim/**/*.h",
 ]
 # exclude = [
 #     "zstd",

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -30,6 +30,7 @@ include = [
     "/zstd/lib/**/*.c",
     "/zstd/lib/**/*.h",
     "/zstd/lib/**/*.S",
+    "/wasm-shim/**/*.h",
 ]
 # exclude = [
 #     "zstd",


### PR DESCRIPTION
Building the released `0.11` does not work for `wasm32-unknown-unknown`, while the build does work for the same revision from Git. 

In the process of making an example (https://github.com/kylebarron/zstd-rs-wasm-bug-example), I realized the shim files were likely not included in the release. `cargo package --list` in `zstd-sys` confirmed that previously the `wasm-shim` files were not included in the build.