### PR TITLE
Unconditionally enable thin LTO in for `zstd-sys`

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -135,12 +135,13 @@ fn compile_zstd() {
 
     config.define("ZSTD_LIB_DEPRECATED", Some("0"));
 
+    config.flag_if_supported("-flto=thin");
+
     #[cfg(feature = "thin")]
     {
         config.define("HUF_FORCE_DECOMPRESS_X1", Some("1"));
         config.define("ZSTD_FORCE_DECOMPRESS_SEQUENCES_SHORT", Some("1"));
         config.define("ZSTD_NO_INLINE ", Some("1"));
-        config.flag_if_supported("-flto=thin");
         config.flag_if_supported("-Oz");
     }
 


### PR DESCRIPTION
Fat LTO usually can reduce binary size while improving the performance.
Thin LTO does the same, but taking less time.

Signed-off-by: Jiahao XU [Jiahao_XU@outlook.com](mailto:Jiahao_XU@outlook.com)