### PR TITLE
Deterministic file adding order in compile_zstd()

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -92,10 +92,9 @@ fn compile_zstd() {
         #[cfg(feature = "legacy")]
         "zstd/lib/legacy",
     ] {
-        let mut entries: Vec<_> = fs::read_dir(dir).unwrap().map(|r| r.unwrap()).collect();
-        entries.sort_by_key(|k| k.path());
-        for entry in entries {
-            let path = entry.path();
+        let mut entries: Vec<_> = fs::read_dir(dir).unwrap().map(|r| r.unwrap().path()).collect();
+        entries.sort();
+        for path in entries {
             // Skip xxhash*.c files: since we are using the "PRIVATE API"
             // mode, it will be inlined in the headers.
             if path

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -92,8 +92,10 @@ fn compile_zstd() {
         #[cfg(feature = "legacy")]
         "zstd/lib/legacy",
     ] {
-        for entry in fs::read_dir(dir).unwrap() {
-            let path = entry.unwrap().path();
+        let mut entries: Vec<_> = fs::read_dir(dir).unwrap().map(|r| r.unwrap()).collect();
+        entries.sort_by_key(|k| k.path());
+        for entry in entries {
+            let path = entry.path();
             // Skip xxhash*.c files: since we are using the "PRIVATE API"
             // mode, it will be inlined in the headers.
             if path


### PR DESCRIPTION
This is to make the build more deterministic.

Note that `fs::read_dir()`'s behavior is platform-specific. We sort the
returned result of `read_dir` to make the file addition order
deterministic.