### PR TITLE
Disable unused features of dep `bindgen`

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -49,6 +49,8 @@ doctest=false  # Documentation is for C code, good luck testing that.
 [build-dependencies.bindgen]
 optional = true
 version = "0.60"
+default-features = false
+features = ["runtime", "which-rustfmt"]
 
 [build-dependencies.pkg-config]
 optional = true


### PR DESCRIPTION
`bindgen` enables feature "clap" and "logging" by default, which is used only in binary but not in library.