### PR TITLE
add environment variable to force usage of pkg-config

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -69,6 +69,7 @@ debug = [] # Enable zstd debug logs
 experimental = [] # Expose experimental ZSTD API
 legacy = [] # Enable legacy ZSTD support (for versions < zstd-0.8)
 non-cargo = [] # Silence cargo-specific build flags
+pkg-config = []
 std = [] # Use std types instead of libc in bindgen
 zstdmt = [] # Enable multi-thread support (with pthread)
 thin = [] # Optimize binary by size

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -53,7 +53,6 @@ default-features = false
 features = ["runtime", "which-rustfmt"]
 
 [build-dependencies.pkg-config]
-optional = true
 version = "0.3"
 
 [build-dependencies.cc]

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -188,6 +188,7 @@ fn compile_zstd() {
 }
 
 fn main() {
+    #[cfg(not(feature = "non-cargo"))]
     println!("cargo:rerun-if-env-changed=ZSTD_SYS_USE_PKG_CONFIG");
 
     let target_arch =

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -38,7 +38,6 @@ fn generate_bindings(defs: Vec<&str>, headerpaths: Vec<PathBuf>) {
 #[cfg(not(feature = "bindgen"))]
 fn generate_bindings(_: Vec<&str>, _: Vec<PathBuf>) {}
 
-#[cfg(feature = "pkg-config")]
 fn pkg_config() -> (Vec<&'static str>, Vec<PathBuf>) {
     let library = pkg_config::Config::new()
         .statik(true)
@@ -46,11 +45,6 @@ fn pkg_config() -> (Vec<&'static str>, Vec<PathBuf>) {
         .probe("libzstd")
         .expect("Can't probe for zstd in pkg-config");
     (vec!["PKG_CONFIG"], library.include_paths)
-}
-
-#[cfg(not(feature = "pkg-config"))]
-fn pkg_config() -> (Vec<&'static str>, Vec<PathBuf>) {
-    unimplemented!()
 }
 
 #[cfg(not(feature = "legacy"))]
@@ -194,6 +188,8 @@ fn compile_zstd() {
 }
 
 fn main() {
+    println!("cargo:rerun-if-env-changed=ZSTD_SYS_USE_PKG_CONFIG");
+
     let target_arch =
         std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
@@ -203,7 +199,9 @@ fn main() {
     }
 
     // println!("cargo:rustc-link-lib=zstd");
-    let (defs, headerpaths) = if cfg!(feature = "pkg-config") {
+    let (defs, headerpaths) = if cfg!(feature = "pkg-config")
+        || env::var_os("ZSTD_SYS_USE_PKG_CONFIG").is_some()
+    {
         pkg_config()
     } else {
         if !Path::new("zstd/lib").exists() {


### PR DESCRIPTION
fixes #150 

this makes pkg-config a non-optional build-dependency

now having `ZSTD_SYS_USE_PKG_CONFIG` will be equivalent to having the pkg-config feature