### PR TITLE
zstd-sys: Don't use `target*` cfg in `build.rs` to fix Windows cross-compile

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -114,7 +114,7 @@ fn compile_zstd() {
 
     // Either include ASM files, or disable ASM entirely.
     // Also disable it on windows, apparently it doesn't do well with these .S files at the moment.
-    if cfg!(any(target_os = "windows", feature = "no_asm")) {
+    if cfg!(feature = "no_asm") || std::env::var("CARGO_CFG_WINDOWS").is_ok() {
         config.define("ZSTD_DISABLE_ASM", Some(""));
     } else {
         config.file("zstd/lib/decompress/huf_decompress_amd64.S");


### PR DESCRIPTION
This issue got exposed with [CC upgrading to 1.0.77] and now detecting the `.S` file extension to pass on to `ml64.exe` (MASM) on Windows; we don't have that on our cross-compiling (from Linux to Windows) CI setup, hence uncovered that this build script was using the _`target_os` flag from the host_ in the build script to make a decision on _what to compile for the target_.

[CC upgrading to 1.0.77]: https://github.com/rust-lang/cc-rs/compare/1.0.76...1.0.77

---

Curiously this implies the `.S` file must have compiled fine for us on `cc 1.0.76` and prior, or somehow got skipped (expecting errors when `ZSTD_DISABLE_ASM` isn't defined...).
