### PR TITLE
Add support for skippable frames

### DIFF
--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -130,6 +130,9 @@ pub struct Status {
     pub bytes_written: usize,
 }
 
+/// The magic variant encoded in a skippable frame.
+pub struct MagicVariant(pub u8);
+
 /// An in-memory decoder for streams of data.
 pub struct Decoder<'a> {
     context: zstd_safe::DCtx<'a>,
@@ -173,6 +176,29 @@ impl<'a> Decoder<'a> {
             .set_parameter(parameter)
             .map_err(map_error_code)?;
         Ok(())
+    }
+
+    #[cfg(feature = "experimental")]
+    // TODO: remove self?
+    /// Read a skippable frame.
+    pub fn read_skippable_frame(&self, dest: &mut Vec<u8>, input: &[u8]) -> io::Result<(usize, MagicVariant)> {
+        use zstd_safe::DCtx;
+
+        let mut magic_variant = 0;
+        DCtx::read_skippable_frame(&mut OutBuffer::around(dest), &mut magic_variant, input)
+            .map(|written| (written, MagicVariant(magic_variant as u8)))
+            .map_err(map_error_code)
+    }
+
+    #[cfg(feature = "experimental")]
+    // TODO: remove self?
+    /// Check if a frame is skippable.
+    pub fn is_skippable_frame(&self, input: &[u8]) -> io::Result<bool> {
+        use zstd_safe::DCtx;
+
+        DCtx::is_skippable_frame(input)
+            .map(|is_skippable| is_skippable != 0)
+            .map_err(map_error_code)
     }
 }
 

--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -182,10 +182,8 @@ impl<'a> Decoder<'a> {
     // TODO: remove self?
     /// Read a skippable frame.
     pub fn read_skippable_frame(&self, dest: &mut Vec<u8>, input: &[u8]) -> io::Result<(usize, MagicVariant)> {
-        use zstd_safe::DCtx;
-
         let mut magic_variant = 0;
-        DCtx::read_skippable_frame(&mut OutBuffer::around(dest), &mut magic_variant, input)
+        zstd_safe::read_skippable_frame(dest, &mut magic_variant, input)
             .map(|written| (written, MagicVariant(magic_variant as u8)))
             .map_err(map_error_code)
     }
@@ -193,12 +191,8 @@ impl<'a> Decoder<'a> {
     #[cfg(feature = "experimental")]
     // TODO: remove self?
     /// Check if a frame is skippable.
-    pub fn is_skippable_frame(&self, input: &[u8]) -> io::Result<bool> {
-        use zstd_safe::DCtx;
-
-        DCtx::is_skippable_frame(input)
-            .map(|is_skippable| is_skippable != 0)
-            .map_err(map_error_code)
+    pub fn is_skippable_frame(&self, input: &[u8]) -> bool {
+        zstd_safe::is_skippable_frame(input)
     }
 }
 

--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -154,7 +154,7 @@ impl<'a, R: Read + Seek> Decoder<'a, BufReader<R>> {
             let op = self.reader.operation();
             // FIXME: I feel like we should do that check right after reading the magic number, but
             // ZSTD does it after reading the content size.
-            if !op.is_skippable_frame(&magic_buffer)? {
+            if !op.is_skippable_frame(&magic_buffer) {
                 bytes_to_seek = U32_SIZE * 2;
                 return Err(io::Error::new(io::ErrorKind::Other, "Unsupported frame parameter"));
             }

--- a/src/stream/write/mod.rs
+++ b/src/stream/write/mod.rs
@@ -190,6 +190,12 @@ impl<W: Write> Encoder<'static, W> {
         let writer = zio::Writer::new(writer, encoder);
         Ok(Encoder { writer })
     }
+
+    /// Write a skippable frame.
+    #[cfg(feature = "experimental")]
+    pub fn write_skippable_frame(&mut self, buf: &[u8], magic_variant: u32) -> io::Result<()> {
+        self.writer.write_skippable_frame(buf, magic_variant)
+    }
 }
 
 impl<'a, W: Write> Encoder<'a, W> {
@@ -255,6 +261,12 @@ impl<'a, W: Write> Encoder<'a, W> {
     ///           `AutoFinishEncoder`.
     pub fn finish(self) -> io::Result<W> {
         self.try_finish().map_err(|(_, err)| err)
+    }
+
+    /// Useful to get back the writer after calling write_skippable_frame. You don't want to call
+    /// finish because this will create yet another frame.
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner().0
     }
 
     /// **Required**: Attempts to finish the stream.

--- a/src/stream/zio/reader.rs
+++ b/src/stream/zio/reader.rs
@@ -47,6 +47,11 @@ impl<R, D> Reader<R, D> {
         self.single_frame = true;
     }
 
+    /// Returns a reference to the underlying operation.
+    pub fn operation(&self) -> &D {
+        &self.operation
+    }
+
     /// Returns a mutable reference to the underlying operation.
     pub fn operation_mut(&mut self) -> &mut D {
         &mut self.operation

--- a/src/stream/zio/writer.rs
+++ b/src/stream/zio/writer.rs
@@ -349,8 +349,8 @@ mod tests {
         let mut decoder = Decoder::new(data).unwrap().single_frame();
 
         let mut frame = vec![0; 20];
-        decoder.read_skippable_frame(&mut frame).unwrap();
-        assert_eq!("test content", String::from_utf8_lossy(&frame));
+        let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
+        assert_eq!("test content", String::from_utf8_lossy(&frame[..size]));
 
         let inner = decoder.finish();
 
@@ -370,8 +370,8 @@ mod tests {
                 .single_frame()
         };
 
-        decoder.read_skippable_frame(&mut frame).unwrap();
-        assert_eq!("SKIP", String::from_utf8_lossy(&frame));
+        let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
+        assert_eq!("SKIP", String::from_utf8_lossy(&frame[..size]));
 
         decoder.skip_frame().unwrap();
 
@@ -382,8 +382,8 @@ mod tests {
                 .single_frame()
         };
 
-        decoder.read_skippable_frame(&mut frame).unwrap();
-        assert_eq!("end", String::from_utf8_lossy(&frame));
+        let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
+        assert_eq!("end", String::from_utf8_lossy(&frame[..size]));
 
         let inner = decoder.finish();
 
@@ -429,10 +429,10 @@ mod tests {
         };
 
         let mut frame = vec![0; 20];
-        decoder.read_skippable_frame(&mut frame).unwrap();
-        assert_eq!("SKIP", String::from_utf8_lossy(&frame));
+        let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
+        assert_eq!("SKIP", String::from_utf8_lossy(&frame[..size]));
 
-        decoder.read_skippable_frame(&mut frame).unwrap();
-        assert_eq!("second skip frame", String::from_utf8_lossy(&frame));
+        let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
+        assert_eq!("second skip frame", String::from_utf8_lossy(&frame[..size]));
     }
 }

--- a/src/stream/zio/writer.rs
+++ b/src/stream/zio/writer.rs
@@ -134,15 +134,13 @@ where
     /// Write a skippable frame after finishing the previous frame if needed.
     #[cfg(feature = "experimental")]
     pub fn write_skippable_frame(&mut self, buf: &[u8], magic_variant: u32) -> io::Result<()> {
-        use zstd_safe::CCtx;
-
         use crate::map_error_code;
 
         if self.writing_frame {
             self.finish()?; // Since we're about to overwrite the buffer, flush its content to the destination.
         }
 
-        CCtx::write_skippable_frame(&mut OutBuffer::around(&mut self.buffer), buf, magic_variant)
+        zstd_safe::write_skippable_frame(&mut self.buffer, buf, magic_variant)
             .map_err(map_error_code)?;
         self.offset = 0;
         self.write_from_offset()?;

--- a/src/stream/zio/writer.rs
+++ b/src/stream/zio/writer.rs
@@ -358,6 +358,8 @@ mod tests {
         };
 
         let mut target = vec![];
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
         io::copy(&mut decoder, &mut target).unwrap();
         assert_eq!("compressed frame 1", String::from_utf8(target).unwrap());
 
@@ -371,6 +373,8 @@ mod tests {
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("SKIP", String::from_utf8_lossy(&frame[..size]));
 
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
         decoder.skip_frame().unwrap();
 
         let inner = decoder.finish();
@@ -391,6 +395,8 @@ mod tests {
         };
 
         let mut target = vec![];
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
+        assert!(decoder.read_skippable_frame(&mut frame).is_err());
         io::copy(&mut decoder, &mut target).unwrap();
         assert_eq!("compressed frame 3", String::from_utf8(target).unwrap());
     }

--- a/src/stream/zio/writer.rs
+++ b/src/stream/zio/writer.rs
@@ -346,7 +346,7 @@ mod tests {
         // Decompress and skip a frame.
         let mut decoder = Decoder::new(data).unwrap().single_frame();
 
-        let mut frame = vec![0; 20];
+        let mut frame = vec![];
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("test content", String::from_utf8_lossy(&frame[..size]));
 
@@ -370,6 +370,7 @@ mod tests {
                 .single_frame()
         };
 
+        let mut frame = vec![];
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("SKIP", String::from_utf8_lossy(&frame[..size]));
 
@@ -384,6 +385,7 @@ mod tests {
                 .single_frame()
         };
 
+        let mut frame = vec![];
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("end", String::from_utf8_lossy(&frame[..size]));
 
@@ -432,10 +434,11 @@ mod tests {
                 .single_frame()
         };
 
-        let mut frame = vec![0; 20];
+        let mut frame = vec![];
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("SKIP", String::from_utf8_lossy(&frame[..size]));
 
+        let mut frame = vec![];
         let (size, _) = decoder.read_skippable_frame(&mut frame).unwrap();
         assert_eq!("second skip frame", String::from_utf8_lossy(&frame[..size]));
     }


### PR DESCRIPTION
Hi.
This add supports for writing and reading skippable frames as well as skipping frames.

There is no support for doing that in a streaming way in the ZSTD C library, so that's why so part of this PR parses some stuff manually.

There are a few TODOs in the code that I'd like you to tell what you think we should do with that.

Thanks for the review.