### PR TITLE
refactor `*.c` files discovery in `compile_zstd`

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -101,22 +101,21 @@ fn compile_zstd() {
         let mut entries: Vec<_> = fs::read_dir(dir)
             .unwrap()
             .map(|r| r.unwrap().path())
-            .collect();
-        entries.sort();
-        for path in entries {
+            .filter(|path| path.extension() == Some(OsStr::new("c")))
             // Skip xxhash*.c files: since we are using the "PRIVATE API"
             // mode, it will be inlined in the headers.
-            if path
-                .file_name()
-                .and_then(|p| p.to_str())
-                .map_or(false, |p| p.contains("xxhash"))
-            {
-                continue;
-            }
-            if path.extension() == Some(OsStr::new("c")) {
-                config.file(path);
-            }
-        }
+            .filter(|path| {
+               !path
+                    .file_name()
+                    // If path.extension() is Some, then file_name cannot be None.
+                    .unwrap()
+                    .to_string_lossy()
+                    .contains("xxhash")
+            })
+            .collect();
+        entries.sort();
+
+        config.files(entries);
     }
 
     // Either include ASM files, or disable ASM entirely.


### PR DESCRIPTION
Use iterator-style loop instead of for-loop while also reducing size of the `entries: Vec<_>` by filtering out unwanted `entry` before `collect`ing into a `Vec<_>`.

Also, use `Build::files` instead of `Build::file` to avoid the for-loop.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>