### PR TITLE
Fix `main` in `zstd-sys` `build.rs`: Use `var_os` for `CARGO_MANIFEST_DIR`

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -248,7 +248,7 @@ fn main() {
         }
 
         let manifest_dir = PathBuf::from(
-            env::var("CARGO_MANIFEST_DIR")
+            env::var_os("CARGO_MANIFEST_DIR")
                 .expect("Manifest dir is always set by cargo"),
         );
 


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>