### PR TITLE
Re-enable lto support guarded behind feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ no_asm = ["zstd-safe/no_asm"]
 doc-cfg = []
 zdict_builder = ["zstd-safe/zdict_builder"]
 
+fat-lto = ["zstd-safe/fat-lto"]
+thin-lto = ["zstd-safe/thin-lto"]
+
 [[example]]
 name = "train"
 required-features = ["zdict_builder"]

--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -34,3 +34,6 @@ arrays = []
 no_asm = ["zstd-sys/no_asm"]
 doc-cfg = []
 zdict_builder = ["zstd-sys/zdict_builder"]
+
+fat-lto = ["zstd-sys/fat-lto"]
+thin-lto = ["zstd-sys/thin-lto"]

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -76,3 +76,6 @@ zstdmt = [] # Enable multi-thread support (with pthread)
 thin = [] # Optimize binary by size
 no_asm = [] # Disable ASM files (only on amd64 for decompression)
 zdict_builder = []
+
+fat-lto = [] # Enable fat-lto, will override thin-lto if specified
+thin-lto = [] # Enable thin-lto, will fallback to fat-lto if not supported

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -151,16 +151,14 @@ fn compile_zstd() {
         .flag_if_supported("-Wl,--gc-sections")
         .flag_if_supported("-Wl,--icf=safe");
 
-    // TODO: re-enable thin lto when a more robust solution is found.
-    /*
-    if config.get_compiler().is_like_gnu() {
-        config.flag_if_supported("-fwhopr");
-    } else {
-        // gcc has a -flto but not -flto=thin
-        // Apparently this is causing crashes on windows-gnu?
-        config.flag_if_supported("-flto=thin");
+    if cfg!(feature = "fat-lto") {
+        config.flag_if_supported("-flto");
+    } else if cfg!(feature = "thin-lto") {
+        flag_if_supported_with_fallbacks(
+            &mut config,
+            &["-flto=thin", "-flto"],
+        );
     }
-    */
 
     #[cfg(feature = "thin")]
     {


### PR DESCRIPTION
 - fat-lto for fat lto, will override thin-lto if specified
 - thin-lto for thin lto, will fallback to fat-lto is not supported

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>