### PR TITLE
Fix zstd-sys for wasm32-unknown-emscripten

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -128,10 +128,11 @@ fn compile_zstd() {
         config.file("zstd/lib/decompress/huf_decompress_amd64.S");
     }
 
-    let is_wasm = env::var("TARGET")
-        .map_or(false, |target| target.starts_with("wasm32-"));
+    let need_wasm_shim = env::var("TARGET").map_or(false, |target| {
+        target == "wasm32-unknown-unknown" || target == "wasm32-wasi"
+    });
 
-    if is_wasm {
+    if need_wasm_shim {
         cargo_print(&"rerun-if-changed=wasm-shim/stdlib.h");
         cargo_print(&"rerun-if-changed=wasm-shim/string.h");
 

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -128,6 +128,10 @@ fn compile_zstd() {
         config.file("zstd/lib/decompress/huf_decompress_amd64.S");
     }
 
+    // List out the WASM targets that need wasm-shim.
+    // Note that Emscripten already provides its own C standard library so
+    // wasm32-unknown-emscripten should not be included here.
+    // See: https://github.com/gyscos/zstd-rs/pull/209
     let need_wasm_shim = env::var("TARGET").map_or(false, |target| {
         target == "wasm32-unknown-unknown" || target == "wasm32-wasi"
     });


### PR DESCRIPTION
This PR disables wasm-shim for wasm32-unknown-emscripten, which provides its own stdlib.h and string.h so does not need wasm-shim.

Without this PR, running `cargo build --target wasm32-unknown-emscripten` fails for zstd-sys:
```
  cargo:warning=zstd/lib/dictBuilder/cover.c:262:10: error: call to undeclared library function 'memcmp' with type 'int (const void *, const void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=  return memcmp(ctx->samples + lhs, ctx->samples + rhs, ctx->d);
  cargo:warning=         ^
  cargo:warning=zstd/lib/dictBuilder/cover.c:262:10: note: include the header <string.h> or explicitly provide a declaration for 'memcmp'
  cargo:warning=zstd/lib/dictBuilder/cover.c:629:5: error: call to undeclared function 'qsort'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=    qsort(ctx->suffix, ctx->suffixSize, sizeof(U32),
  cargo:warning=    ^
  cargo:warning=2 errors generated.
  cargo:warning=emcc: error: '/Users/hzuo/git/emsdk/upstream/bin/clang -target wasm32-unknown-emscripten -fignore-exceptions -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -DEMSCRIPTEN -Werror=implicit-function-declaration --sysroot=/Users/hzuo/git/emsdk/upstream/emscripten/cache/sysroot -Xclang -iwithsysroot/include/fakesdl -Xclang -iwithsysroot/include/compat -O0 -ffunction-sections -fdata-sections -fPIC -g3 -fno-omit-frame-pointer -Iwasm-shim/ -Izstd/lib/ -Izstd/lib/common -Izstd/lib/legacy -fvisibility=hidden -ffunction-sections -fdata-sections -fmerge-all-constants -DXXH_STATIC_ASSERT=0 -DZSTD_LIB_DEPRECATED=0 -DXXH_PRIVATE_API= -DZSTDLIB_VISIBILITY= -DZDICTLIB_VISIBILITY= -DZSTDERRORLIB_VISIBILITY= -DZSTD_LEGACY_SUPPORT=1 -c zstd/lib/dictBuilder/cover.c -o /Users/hzuo/git/zstd-rs/zstd-safe/zstd-sys/target/wasm32-unknown-emscripten/debug/build/zstd-sys-43d1d83f7a3975f5/out/zstd/lib/dictBuilder/cover.o' failed (returned 1)
```

It fails because `memcmp` and `qsort` are not provided by the shim.

This was a regression introduced in #183 where adding the check for wasm32-wasi was too broad and ended up including Emscripten as well.

Separately, I wonder if `memcmp` and `qsort` should be introduced to wasm-shim so that zstd can be built for wasm32-unknown-unknown and wasm32-wasi without needing to `--disable-default-features`? Specifically the `zdict_builder` feature requires these two functions be shimmed.
