### PR TITLE
Fix OutBuf around_pos invariant

### DIFF
--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -1710,9 +1710,9 @@ impl<'a, C: WriteBuf + ?Sized> OutBuffer<'a, C> {
     ///
     /// # Panics
     ///
-    /// If `pos >= dst.capacity()`.
+    /// If `pos > dst.capacity()`.
     pub fn around_pos(dst: &'a mut C, pos: usize) -> Self {
-        if pos >= dst.capacity() {
+        if pos > dst.capacity() {
             panic!("Given position outside of the buffer bounds.");
         }
 


### PR DESCRIPTION
Changes the invariant for the `around_pos()` constructor to not panic when the valid case of constructing an empty `OutBuf`. This constructor was inconsistent with the documentation for the struct and the `set_pos()` method. [Zstd documentation](https://github.com/facebook/zstd/blob/95ffc767f62e8aaeba363af49a590f8662cc2465/lib/zstd.h#L670) also confirms that empty buffer is a valid use case.

Fixes #214 

