### PR TITLE
Bump zstd-safe patch version

### DIFF
--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Alexandre Bury <alexandre.bury@gmail.com>"]
 name = "zstd-safe"
 build = "build.rs"
-version = "6.0.4+zstd.1.5.4"
+version = "6.0.5+zstd.1.5.4"
 description = "Safe low-level bindings for the zstd compression library."
 keywords = ["zstd", "zstandard", "compression"]
 categories = ["api-bindings", "compression"]


### PR DESCRIPTION
Merging and publishing would allow #215 to be fixed. If there are other changes maybe this needs to be a minor bump.