### PR TITLE
Swap libc to `core::ffi`

### DIFF
--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -17,7 +17,6 @@ features = ["experimental", "arrays", "std", "zdict_builder", "doc-cfg"]
 
 [dependencies]
 zstd-sys = { path = "zstd-sys", version = "2.0.7", default-features = false }
-libc = "0.2.21"
 
 [features]
 default = ["legacy", "arrays", "zdict_builder"]

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -38,7 +38,7 @@ pub use zstd_sys::ZSTD_strategy as Strategy;
 use std::os::raw::{c_char, c_int, c_ulonglong, c_void};
 
 #[cfg(not(feature = "std"))]
-use libc::{c_char, c_int, c_ulonglong, c_void};
+use core::ffi::{c_char, c_int, c_ulonglong, c_void};
 
 use core::marker::PhantomData;
 use core::num::{NonZeroU32, NonZeroU64};
@@ -819,12 +819,9 @@ unsafe impl<'a> Send for CCtx<'a> {}
 unsafe fn c_char_to_str(text: *const c_char) -> &'static str {
     #[cfg(not(feature = "std"))]
     {
-        // To be safe, we need to compute right now its length
-        let len = libc::strlen(text);
-        // Cast it to a slice
-        let slice = core::slice::from_raw_parts(text as *mut u8, len);
-        // And hope it's still text.
-        str::from_utf8(slice).expect("bad error message from zstd")
+        core::ffi::CStr::from_ptr(text)
+            .to_str()
+            .expect("bad error message from zstd")
     }
 
     #[cfg(feature = "std")]

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -60,9 +60,6 @@ version = "0.3"
 version = "1.0.45"
 features = ["parallel"]
 
-[dependencies]
-libc = "0.2.45"
-
 [features]
 default = ["legacy", "zdict_builder"]
 

--- a/zstd-safe/zstd-sys/src/bindings_zdict.rs
+++ b/zstd-safe/zstd-sys/src/bindings_zdict.rs
@@ -38,51 +38,51 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern "C" {
     #[doc = " ZDICT_trainFromBuffer():\n  Train a dictionary from an array of samples.\n  Redirect towards ZDICT_optimizeTrainFromBuffer_fastCover() single-threaded, with d=8, steps=4,\n  f=20, and accel=1.\n  Samples must be stored concatenated in a single flat buffer `samplesBuffer`,\n  supplied with an array of sizes `samplesSizes`, providing the size of each sample, in order.\n  The resulting dictionary will be saved into `dictBuffer`.\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n  Note:  Dictionary training will fail if there are not enough samples to construct a\n         dictionary, or if most of the samples are too small (< 8 bytes being the lower limit).\n         If dictionary training fails, you should use zstd without a dictionary, as the dictionary\n         would've been ineffective anyways. If you believe your samples would benefit from a dictionary\n         please open an issue with details, and we can look into it.\n  Note: ZDICT_trainFromBuffer()'s memory usage is about 6 MB.\n  Tips: In general, a reasonable dictionary has a size of ~ 100 KB.\n        It's possible to select smaller or larger size, just by specifying `dictBufferCapacity`.\n        In general, it's recommended to provide a few thousands samples, though this can vary a lot.\n        It's recommended that total size of all samples be about ~x100 times the target size of dictionary."]
     pub fn ZDICT_trainFromBuffer(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
     ) -> usize;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZDICT_params_t {
     #[doc = "< optimize for a specific zstd compression level; 0 means default"]
-    pub compressionLevel: libc::c_int,
+    pub compressionLevel: core::ffi::c_int,
     #[doc = "< Write log to stderr; 0 = none (default); 1 = errors; 2 = progression; 3 = details; 4 = debug;"]
-    pub notificationLevel: libc::c_uint,
+    pub notificationLevel: core::ffi::c_uint,
     #[doc = "< force dictID value; 0 means auto mode (32-bits random value)\n   NOTE: The zstd format reserves some dictionary IDs for future use.\n         You may use them in private settings, but be warned that they\n         may be used by zstd in a public dictionary registry in the future.\n         These dictionary IDs are:\n           - low range  : <= 32767\n           - high range : >= (2^31)"]
-    pub dictID: libc::c_uint,
+    pub dictID: core::ffi::c_uint,
 }
 extern "C" {
     #[doc = " ZDICT_finalizeDictionary():\n Given a custom content as a basis for dictionary, and a set of samples,\n finalize dictionary by adding headers and statistics according to the zstd\n dictionary format.\n\n Samples must be stored concatenated in a flat buffer `samplesBuffer`,\n supplied with an array of sizes `samplesSizes`, providing the size of each\n sample in order. The samples are used to construct the statistics, so they\n should be representative of what you will compress with this dictionary.\n\n The compression level can be set in `parameters`. You should pass the\n compression level you expect to use in production. The statistics for each\n compression level differ, so tuning the dictionary for the compression level\n can help quite a bit.\n\n You can set an explicit dictionary ID in `parameters`, or allow us to pick\n a random dictionary ID for you, but we can't guarantee no collisions.\n\n The dstDictBuffer and the dictContent may overlap, and the content will be\n appended to the end of the header. If the header + the content doesn't fit in\n maxDictSize the beginning of the content is truncated to make room, since it\n is presumed that the most profitable content is at the end of the dictionary,\n since that is the cheapest to reference.\n\n `maxDictSize` must be >= max(dictContentSize, ZSTD_DICTSIZE_MIN).\n\n @return: size of dictionary stored into `dstDictBuffer` (<= `maxDictSize`),\n          or an error code, which can be tested by ZDICT_isError().\n Note: ZDICT_finalizeDictionary() will push notifications into stderr if\n       instructed to, using notificationLevel>0.\n NOTE: This function currently may fail in several edge cases including:\n         * Not enough samples\n         * Samples are uncompressible\n         * Samples are all exactly the same"]
     pub fn ZDICT_finalizeDictionary(
-        dstDictBuffer: *mut libc::c_void,
+        dstDictBuffer: *mut core::ffi::c_void,
         maxDictSize: usize,
-        dictContent: *const libc::c_void,
+        dictContent: *const core::ffi::c_void,
         dictContentSize: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: ZDICT_params_t,
     ) -> usize;
 }
 extern "C" {
     pub fn ZDICT_getDictID(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     pub fn ZDICT_getDictHeaderSize(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
 extern "C" {
-    pub fn ZDICT_isError(errorCode: usize) -> libc::c_uint;
+    pub fn ZDICT_isError(errorCode: usize) -> core::ffi::c_uint;
 }
 extern "C" {
-    pub fn ZDICT_getErrorName(errorCode: usize) -> *const libc::c_char;
+    pub fn ZDICT_getErrorName(errorCode: usize) -> *const core::ffi::c_char;
 }

--- a/zstd-safe/zstd-sys/src/bindings_zdict_experimental.rs
+++ b/zstd-safe/zstd-sys/src/bindings_zdict_experimental.rs
@@ -40,149 +40,149 @@ pub const ZDICT_CONTENTSIZE_MIN: u32 = 128;
 extern "C" {
     #[doc = " ZDICT_trainFromBuffer():\n  Train a dictionary from an array of samples.\n  Redirect towards ZDICT_optimizeTrainFromBuffer_fastCover() single-threaded, with d=8, steps=4,\n  f=20, and accel=1.\n  Samples must be stored concatenated in a single flat buffer `samplesBuffer`,\n  supplied with an array of sizes `samplesSizes`, providing the size of each sample, in order.\n  The resulting dictionary will be saved into `dictBuffer`.\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n  Note:  Dictionary training will fail if there are not enough samples to construct a\n         dictionary, or if most of the samples are too small (< 8 bytes being the lower limit).\n         If dictionary training fails, you should use zstd without a dictionary, as the dictionary\n         would've been ineffective anyways. If you believe your samples would benefit from a dictionary\n         please open an issue with details, and we can look into it.\n  Note: ZDICT_trainFromBuffer()'s memory usage is about 6 MB.\n  Tips: In general, a reasonable dictionary has a size of ~ 100 KB.\n        It's possible to select smaller or larger size, just by specifying `dictBufferCapacity`.\n        In general, it's recommended to provide a few thousands samples, though this can vary a lot.\n        It's recommended that total size of all samples be about ~x100 times the target size of dictionary."]
     pub fn ZDICT_trainFromBuffer(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
     ) -> usize;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZDICT_params_t {
     #[doc = "< optimize for a specific zstd compression level; 0 means default"]
-    pub compressionLevel: libc::c_int,
+    pub compressionLevel: core::ffi::c_int,
     #[doc = "< Write log to stderr; 0 = none (default); 1 = errors; 2 = progression; 3 = details; 4 = debug;"]
-    pub notificationLevel: libc::c_uint,
+    pub notificationLevel: core::ffi::c_uint,
     #[doc = "< force dictID value; 0 means auto mode (32-bits random value)\n   NOTE: The zstd format reserves some dictionary IDs for future use.\n         You may use them in private settings, but be warned that they\n         may be used by zstd in a public dictionary registry in the future.\n         These dictionary IDs are:\n           - low range  : <= 32767\n           - high range : >= (2^31)"]
-    pub dictID: libc::c_uint,
+    pub dictID: core::ffi::c_uint,
 }
 extern "C" {
     #[doc = " ZDICT_finalizeDictionary():\n Given a custom content as a basis for dictionary, and a set of samples,\n finalize dictionary by adding headers and statistics according to the zstd\n dictionary format.\n\n Samples must be stored concatenated in a flat buffer `samplesBuffer`,\n supplied with an array of sizes `samplesSizes`, providing the size of each\n sample in order. The samples are used to construct the statistics, so they\n should be representative of what you will compress with this dictionary.\n\n The compression level can be set in `parameters`. You should pass the\n compression level you expect to use in production. The statistics for each\n compression level differ, so tuning the dictionary for the compression level\n can help quite a bit.\n\n You can set an explicit dictionary ID in `parameters`, or allow us to pick\n a random dictionary ID for you, but we can't guarantee no collisions.\n\n The dstDictBuffer and the dictContent may overlap, and the content will be\n appended to the end of the header. If the header + the content doesn't fit in\n maxDictSize the beginning of the content is truncated to make room, since it\n is presumed that the most profitable content is at the end of the dictionary,\n since that is the cheapest to reference.\n\n `maxDictSize` must be >= max(dictContentSize, ZSTD_DICTSIZE_MIN).\n\n @return: size of dictionary stored into `dstDictBuffer` (<= `maxDictSize`),\n          or an error code, which can be tested by ZDICT_isError().\n Note: ZDICT_finalizeDictionary() will push notifications into stderr if\n       instructed to, using notificationLevel>0.\n NOTE: This function currently may fail in several edge cases including:\n         * Not enough samples\n         * Samples are uncompressible\n         * Samples are all exactly the same"]
     pub fn ZDICT_finalizeDictionary(
-        dstDictBuffer: *mut libc::c_void,
+        dstDictBuffer: *mut core::ffi::c_void,
         maxDictSize: usize,
-        dictContent: *const libc::c_void,
+        dictContent: *const core::ffi::c_void,
         dictContentSize: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: ZDICT_params_t,
     ) -> usize;
 }
 extern "C" {
     pub fn ZDICT_getDictID(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     pub fn ZDICT_getDictHeaderSize(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
 extern "C" {
-    pub fn ZDICT_isError(errorCode: usize) -> libc::c_uint;
+    pub fn ZDICT_isError(errorCode: usize) -> core::ffi::c_uint;
 }
 extern "C" {
-    pub fn ZDICT_getErrorName(errorCode: usize) -> *const libc::c_char;
+    pub fn ZDICT_getErrorName(errorCode: usize) -> *const core::ffi::c_char;
 }
 #[doc = " ZDICT_cover_params_t:\n  k and d are the only required parameters.\n  For others, value 0 means default."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZDICT_cover_params_t {
-    pub k: libc::c_uint,
-    pub d: libc::c_uint,
-    pub steps: libc::c_uint,
-    pub nbThreads: libc::c_uint,
+    pub k: core::ffi::c_uint,
+    pub d: core::ffi::c_uint,
+    pub steps: core::ffi::c_uint,
+    pub nbThreads: core::ffi::c_uint,
     pub splitPoint: f64,
-    pub shrinkDict: libc::c_uint,
-    pub shrinkDictMaxRegression: libc::c_uint,
+    pub shrinkDict: core::ffi::c_uint,
+    pub shrinkDictMaxRegression: core::ffi::c_uint,
     pub zParams: ZDICT_params_t,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZDICT_fastCover_params_t {
-    pub k: libc::c_uint,
-    pub d: libc::c_uint,
-    pub f: libc::c_uint,
-    pub steps: libc::c_uint,
-    pub nbThreads: libc::c_uint,
+    pub k: core::ffi::c_uint,
+    pub d: core::ffi::c_uint,
+    pub f: core::ffi::c_uint,
+    pub steps: core::ffi::c_uint,
+    pub nbThreads: core::ffi::c_uint,
     pub splitPoint: f64,
-    pub accel: libc::c_uint,
-    pub shrinkDict: libc::c_uint,
-    pub shrinkDictMaxRegression: libc::c_uint,
+    pub accel: core::ffi::c_uint,
+    pub shrinkDict: core::ffi::c_uint,
+    pub shrinkDictMaxRegression: core::ffi::c_uint,
     pub zParams: ZDICT_params_t,
 }
 extern "C" {
     #[doc = " ZDICT_trainFromBuffer_cover():\n  Train a dictionary from an array of samples using the COVER algorithm.\n  Samples must be stored concatenated in a single flat buffer `samplesBuffer`,\n  supplied with an array of sizes `samplesSizes`, providing the size of each sample, in order.\n  The resulting dictionary will be saved into `dictBuffer`.\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n          See ZDICT_trainFromBuffer() for details on failure modes.\n  Note: ZDICT_trainFromBuffer_cover() requires about 9 bytes of memory for each input byte.\n  Tips: In general, a reasonable dictionary has a size of ~ 100 KB.\n        It's possible to select smaller or larger size, just by specifying `dictBufferCapacity`.\n        In general, it's recommended to provide a few thousands samples, though this can vary a lot.\n        It's recommended that total size of all samples be about ~x100 times the target size of dictionary."]
     pub fn ZDICT_trainFromBuffer_cover(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: ZDICT_cover_params_t,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZDICT_optimizeTrainFromBuffer_cover():\n The same requirements as above hold for all the parameters except `parameters`.\n This function tries many parameter combinations and picks the best parameters.\n `*parameters` is filled with the best parameters found,\n dictionary constructed with those parameters is stored in `dictBuffer`.\n\n All of the parameters d, k, steps are optional.\n If d is non-zero then we don't check multiple values of d, otherwise we check d = {6, 8}.\n if steps is zero it defaults to its default value.\n If k is non-zero then we don't check multiple values of k, otherwise we check steps values in [50, 2000].\n\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n          On success `*parameters` contains the parameters selected.\n          See ZDICT_trainFromBuffer() for details on failure modes.\n Note: ZDICT_optimizeTrainFromBuffer_cover() requires about 8 bytes of memory for each input byte and additionally another 5 bytes of memory for each byte of memory for each thread."]
     pub fn ZDICT_optimizeTrainFromBuffer_cover(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: *mut ZDICT_cover_params_t,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZDICT_trainFromBuffer_fastCover():\n  Train a dictionary from an array of samples using a modified version of COVER algorithm.\n  Samples must be stored concatenated in a single flat buffer `samplesBuffer`,\n  supplied with an array of sizes `samplesSizes`, providing the size of each sample, in order.\n  d and k are required.\n  All other parameters are optional, will use default values if not provided\n  The resulting dictionary will be saved into `dictBuffer`.\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n          See ZDICT_trainFromBuffer() for details on failure modes.\n  Note: ZDICT_trainFromBuffer_fastCover() requires 6 * 2^f bytes of memory.\n  Tips: In general, a reasonable dictionary has a size of ~ 100 KB.\n        It's possible to select smaller or larger size, just by specifying `dictBufferCapacity`.\n        In general, it's recommended to provide a few thousands samples, though this can vary a lot.\n        It's recommended that total size of all samples be about ~x100 times the target size of dictionary."]
     pub fn ZDICT_trainFromBuffer_fastCover(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: ZDICT_fastCover_params_t,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZDICT_optimizeTrainFromBuffer_fastCover():\n The same requirements as above hold for all the parameters except `parameters`.\n This function tries many parameter combinations (specifically, k and d combinations)\n and picks the best parameters. `*parameters` is filled with the best parameters found,\n dictionary constructed with those parameters is stored in `dictBuffer`.\n All of the parameters d, k, steps, f, and accel are optional.\n If d is non-zero then we don't check multiple values of d, otherwise we check d = {6, 8}.\n if steps is zero it defaults to its default value.\n If k is non-zero then we don't check multiple values of k, otherwise we check steps values in [50, 2000].\n If f is zero, default value of 20 is used.\n If accel is zero, default value of 1 is used.\n\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n          On success `*parameters` contains the parameters selected.\n          See ZDICT_trainFromBuffer() for details on failure modes.\n Note: ZDICT_optimizeTrainFromBuffer_fastCover() requires about 6 * 2^f bytes of memory for each thread."]
     pub fn ZDICT_optimizeTrainFromBuffer_fastCover(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: *mut ZDICT_fastCover_params_t,
     ) -> usize;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZDICT_legacy_params_t {
-    pub selectivityLevel: libc::c_uint,
+    pub selectivityLevel: core::ffi::c_uint,
     pub zParams: ZDICT_params_t,
 }
 extern "C" {
     #[doc = " ZDICT_trainFromBuffer_legacy():\n  Train a dictionary from an array of samples.\n  Samples must be stored concatenated in a single flat buffer `samplesBuffer`,\n  supplied with an array of sizes `samplesSizes`, providing the size of each sample, in order.\n  The resulting dictionary will be saved into `dictBuffer`.\n `parameters` is optional and can be provided with values set to 0 to mean \"default\".\n @return: size of dictionary stored into `dictBuffer` (<= `dictBufferCapacity`)\n          or an error code, which can be tested with ZDICT_isError().\n          See ZDICT_trainFromBuffer() for details on failure modes.\n  Tips: In general, a reasonable dictionary has a size of ~ 100 KB.\n        It's possible to select smaller or larger size, just by specifying `dictBufferCapacity`.\n        In general, it's recommended to provide a few thousands samples, though this can vary a lot.\n        It's recommended that total size of all samples be about ~x100 times the target size of dictionary.\n  Note: ZDICT_trainFromBuffer_legacy() will send notifications into stderr if instructed to, using notificationLevel>0."]
     pub fn ZDICT_trainFromBuffer_legacy(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
         parameters: ZDICT_legacy_params_t,
     ) -> usize;
 }
 extern "C" {
     pub fn ZDICT_addEntropyTablesFromBuffer(
-        dictBuffer: *mut libc::c_void,
+        dictBuffer: *mut core::ffi::c_void,
         dictContentSize: usize,
         dictBufferCapacity: usize,
-        samplesBuffer: *const libc::c_void,
+        samplesBuffer: *const core::ffi::c_void,
         samplesSizes: *const usize,
-        nbSamples: libc::c_uint,
+        nbSamples: core::ffi::c_uint,
     ) -> usize;
 }

--- a/zstd-safe/zstd-sys/src/bindings_zstd.rs
+++ b/zstd-safe/zstd-sys/src/bindings_zstd.rs
@@ -50,48 +50,48 @@ pub const ZSTD_CONTENTSIZE_UNKNOWN: i32 = -1;
 pub const ZSTD_CONTENTSIZE_ERROR: i32 = -2;
 extern "C" {
     #[doc = " ZSTD_versionNumber() :\n  Return runtime library version, the value is (MAJOR*100*100 + MINOR*100 + RELEASE)."]
-    pub fn ZSTD_versionNumber() -> libc::c_uint;
+    pub fn ZSTD_versionNumber() -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_versionString() :\n  Return runtime library version, like \"1.4.5\". Requires v1.3.0+."]
-    pub fn ZSTD_versionString() -> *const libc::c_char;
+    pub fn ZSTD_versionString() -> *const core::ffi::c_char;
 }
 extern "C" {
     #[doc = "  Simple API\n/\n/*! ZSTD_compress() :\n  Compresses `src` content as a single zstd compressed frame into already allocated `dst`.\n  NOTE: Providing `dstCapacity >= ZSTD_compressBound(srcSize)` guarantees that zstd will have\n        enough space to successfully compress the data.\n  @return : compressed size written into `dst` (<= `dstCapacity),\n            or an error code if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_compress(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_decompress() :\n  `compressedSize` : must be the _exact_ size of some number of compressed and/or skippable frames.\n  `dstCapacity` is an upper bound of originalSize to regenerate.\n  If user cannot imply a maximum upper bound, it's better to use streaming mode to decompress data.\n  @return : the number of bytes decompressed into `dst` (<= `dstCapacity`),\n            or an errorCode if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_decompress(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         compressedSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_getFrameContentSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_getDecompressedSize() :\n  NOTE: This function is now obsolete, in favor of ZSTD_getFrameContentSize().\n  Both functions work the same way, but ZSTD_getDecompressedSize() blends\n  \"empty\", \"unknown\" and \"error\" results to the same return value (0),\n  while ZSTD_getFrameContentSize() gives them separate return values.\n @return : decompressed size of `src` frame content _if known and not empty_, 0 otherwise."]
     pub fn ZSTD_getDecompressedSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_findFrameCompressedSize() : Requires v1.4.0+\n `src` should point to the start of a ZSTD frame or skippable frame.\n `srcSize` must be >= first frame size\n @return : the compressed size of the first frame starting at `src`,\n           suitable to pass as `srcSize` to `ZSTD_decompress` or similar,\n        or an error code if input is invalid"]
     pub fn ZSTD_findFrameCompressedSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -99,19 +99,19 @@ extern "C" {
     pub fn ZSTD_compressBound(srcSize: usize) -> usize;
 }
 extern "C" {
-    pub fn ZSTD_isError(code: usize) -> libc::c_uint;
+    pub fn ZSTD_isError(code: usize) -> core::ffi::c_uint;
 }
 extern "C" {
-    pub fn ZSTD_getErrorName(code: usize) -> *const libc::c_char;
+    pub fn ZSTD_getErrorName(code: usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ZSTD_minCLevel() -> libc::c_int;
+    pub fn ZSTD_minCLevel() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ZSTD_maxCLevel() -> libc::c_int;
+    pub fn ZSTD_maxCLevel() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ZSTD_defaultCLevel() -> libc::c_int;
+    pub fn ZSTD_defaultCLevel() -> core::ffi::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -130,11 +130,11 @@ extern "C" {
     #[doc = " ZSTD_compressCCtx() :\n  Same as ZSTD_compress(), using an explicit ZSTD_CCtx.\n  Important : in order to behave similarly to `ZSTD_compress()`,\n  this function compresses at requested compression level,\n  __ignoring any other parameter__ .\n  If any advanced parameter was set using the advanced API,\n  they will all be reset. Only `compressionLevel` remains."]
     pub fn ZSTD_compressCCtx(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 #[repr(C)]
@@ -153,9 +153,9 @@ extern "C" {
     #[doc = " ZSTD_decompressDCtx() :\n  Same as ZSTD_decompress(),\n  requires an allocated ZSTD_DCtx.\n  Compatible with sticky parameters."]
     pub fn ZSTD_decompressDCtx(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -219,8 +219,8 @@ pub enum ZSTD_cParameter {
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_bounds {
     pub error: usize,
-    pub lowerBound: libc::c_int,
-    pub upperBound: libc::c_int,
+    pub lowerBound: core::ffi::c_int,
+    pub upperBound: core::ffi::c_int,
 }
 extern "C" {
     #[doc = " ZSTD_cParam_getBounds() :\n  All parameters must belong to an interval with lower and upper bounds,\n  otherwise they will either trigger an error or be automatically clamped.\n @return : a structure, ZSTD_bounds, which contains\n         - an error status field, which must be tested using ZSTD_isError()\n         - lower and upper bounds, both inclusive"]
@@ -231,14 +231,14 @@ extern "C" {
     pub fn ZSTD_CCtx_setParameter(
         cctx: *mut ZSTD_CCtx,
         param: ZSTD_cParameter,
-        value: libc::c_int,
+        value: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_CCtx_setPledgedSrcSize() :\n  Total input data size to be compressed as a single frame.\n  Value will be written in frame header, unless if explicitly forbidden using ZSTD_c_contentSizeFlag.\n  This value will also be controlled at end of frame, and trigger an error if not respected.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Note 1 : pledgedSrcSize==0 actually means zero, aka an empty frame.\n           In order to mean \"unknown content size\", pass constant ZSTD_CONTENTSIZE_UNKNOWN.\n           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new frame.\n  Note 2 : pledgedSrcSize is only valid once, for the next frame.\n           It's discarded at the end of the frame, and replaced by ZSTD_CONTENTSIZE_UNKNOWN.\n  Note 3 : Whenever all input data is provided and consumed in a single round,\n           for example with ZSTD_compress2(),\n           or invoking immediately ZSTD_compressStream2(,,,ZSTD_e_end),\n           this value is automatically overridden by srcSize instead."]
     pub fn ZSTD_CCtx_setPledgedSrcSize(
         cctx: *mut ZSTD_CCtx,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 #[repr(u32)]
@@ -259,9 +259,9 @@ extern "C" {
     #[doc = " ZSTD_compress2() :\n  Behave the same as ZSTD_compressCCtx(), but compression parameters are set using the advanced API.\n  ZSTD_compress2() always starts a new frame.\n  Should cctx hold data from a previously unfinished frame, everything about it is forgotten.\n  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()\n  - The function is always blocking, returns when compression is completed.\n  NOTE: Providing `dstCapacity >= ZSTD_compressBound(srcSize)` guarantees that zstd will have\n        enough space to successfully compress the data, though it is possible it fails for other reasons.\n @return : compressed size written into `dst` (<= `dstCapacity),\n           or an error code if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_compress2(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -285,7 +285,7 @@ extern "C" {
     pub fn ZSTD_DCtx_setParameter(
         dctx: *mut ZSTD_DCtx,
         param: ZSTD_dParameter,
-        value: libc::c_int,
+        value: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -300,7 +300,7 @@ extern "C" {
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_inBuffer_s {
     #[doc = "< start of input buffer"]
-    pub src: *const libc::c_void,
+    pub src: *const core::ffi::c_void,
     #[doc = "< size of input buffer"]
     pub size: usize,
     #[doc = "< position where reading stopped. Will be updated. Necessarily 0 <= pos <= size"]
@@ -312,7 +312,7 @@ pub type ZSTD_inBuffer = ZSTD_inBuffer_s;
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_outBuffer_s {
     #[doc = "< start of output buffer"]
-    pub dst: *mut libc::c_void,
+    pub dst: *mut core::ffi::c_void,
     #[doc = "< size of output buffer"]
     pub size: usize,
     #[doc = "< position where writing stopped. Will be updated. Necessarily 0 <= pos <= size"]
@@ -352,7 +352,7 @@ extern "C" {
     #[doc = " Equivalent to:\n\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_refCDict(zcs, NULL); // clear the dictionary (if any)\n     ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);\n\n Note that ZSTD_initCStream() clears any previously set dictionary. Use the new API\n to compress with a dictionary."]
     pub fn ZSTD_initCStream(
         zcs: *mut ZSTD_CStream,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -406,24 +406,24 @@ extern "C" {
     #[doc = "  Simple dictionary API\n/\n/*! ZSTD_compress_usingDict() :\n  Compression at an explicit compression level using a Dictionary.\n  A dictionary can be any arbitrary data segment (also called a prefix),\n  or a buffer with specified information (see zdict.h).\n  Note : This function loads the dictionary, resulting in significant startup delay.\n         It's intended for a dictionary used only once.\n  Note 2 : When `dict == NULL || dictSize < 8` no dictionary is used."]
     pub fn ZSTD_compress_usingDict(
         ctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_decompress_usingDict() :\n  Decompression using a known Dictionary.\n  Dictionary must be identical to the one used during compression.\n  Note : This function loads the dictionary, resulting in significant startup delay.\n         It's intended for a dictionary used only once.\n  Note : When `dict == NULL || dictSize < 8` no dictionary is used."]
     pub fn ZSTD_decompress_usingDict(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -437,9 +437,9 @@ pub type ZSTD_CDict = ZSTD_CDict_s;
 extern "C" {
     #[doc = " ZSTD_createCDict() :\n  When compressing multiple messages or blocks using the same dictionary,\n  it's recommended to digest the dictionary only once, since it's a costly operation.\n  ZSTD_createCDict() will create a state from digesting a dictionary.\n  The resulting state can be used for future compression operations with very limited startup cost.\n  ZSTD_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.\n @dictBuffer can be released after ZSTD_CDict creation, because its content is copied within CDict.\n  Note 1 : Consider experimental function `ZSTD_createCDict_byReference()` if you prefer to not duplicate @dictBuffer content.\n  Note 2 : A ZSTD_CDict can be created from an empty @dictBuffer,\n      in which case the only thing that it transports is the @compressionLevel.\n      This can be useful in a pipeline featuring ZSTD_compress_usingCDict() exclusively,\n      expecting a ZSTD_CDict parameter with any data, including those without a known dictionary."]
     pub fn ZSTD_createCDict(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> *mut ZSTD_CDict;
 }
 extern "C" {
@@ -450,9 +450,9 @@ extern "C" {
     #[doc = " ZSTD_compress_usingCDict() :\n  Compression using a digested Dictionary.\n  Recommended when same dictionary is used multiple times.\n  Note : compression level is _decided at dictionary creation time_,\n     and frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no)"]
     pub fn ZSTD_compress_usingCDict(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         cdict: *const ZSTD_CDict,
     ) -> usize;
@@ -466,7 +466,7 @@ pub type ZSTD_DDict = ZSTD_DDict_s;
 extern "C" {
     #[doc = " ZSTD_createDDict() :\n  Create a digested dictionary, ready to start decompression operation without startup delay.\n  dictBuffer can be released after DDict creation, as its content is copied inside DDict."]
     pub fn ZSTD_createDDict(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
     ) -> *mut ZSTD_DDict;
 }
@@ -478,9 +478,9 @@ extern "C" {
     #[doc = " ZSTD_decompress_usingDDict() :\n  Decompression using a digested Dictionary.\n  Recommended when same dictionary is used multiple times."]
     pub fn ZSTD_decompress_usingDDict(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         ddict: *const ZSTD_DDict,
     ) -> usize;
@@ -488,30 +488,34 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_getDictID_fromDict() : Requires v1.4.0+\n  Provides the dictID stored within dictionary.\n  if @return == 0, the dictionary is not conformant with Zstandard specification.\n  It can still be loaded, but as a content-only dictionary."]
     pub fn ZSTD_getDictID_fromDict(
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromCDict() : Requires v1.5.0+\n  Provides the dictID of the dictionary loaded into `cdict`.\n  If @return == 0, the dictionary is not conformant to Zstandard specification, or empty.\n  Non-conformant dictionaries can still be loaded, but as content-only dictionaries."]
-    pub fn ZSTD_getDictID_fromCDict(cdict: *const ZSTD_CDict) -> libc::c_uint;
+    pub fn ZSTD_getDictID_fromCDict(
+        cdict: *const ZSTD_CDict,
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromDDict() : Requires v1.4.0+\n  Provides the dictID of the dictionary loaded into `ddict`.\n  If @return == 0, the dictionary is not conformant to Zstandard specification, or empty.\n  Non-conformant dictionaries can still be loaded, but as content-only dictionaries."]
-    pub fn ZSTD_getDictID_fromDDict(ddict: *const ZSTD_DDict) -> libc::c_uint;
+    pub fn ZSTD_getDictID_fromDDict(
+        ddict: *const ZSTD_DDict,
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromFrame() : Requires v1.4.0+\n  Provides the dictID required to decompressed the frame stored within `src`.\n  If @return == 0, the dictID could not be decoded.\n  This could for one of the following reasons :\n  - The frame does not require a dictionary to be decoded (most common case).\n  - The frame was built with dictID intentionally removed. Whatever dictionary is necessary is a hidden piece of information.\n    Note : this use case also happens when using a non-conformant dictionary.\n  - `srcSize` is too small, and as a result, the frame header could not be decoded (only possible if `srcSize < ZSTD_FRAMEHEADERSIZE_MAX`).\n  - This is not a Zstandard frame.\n  When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code."]
     pub fn ZSTD_getDictID_fromFrame(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_CCtx_loadDictionary() : Requires v1.4.0+\n  Create an internal CDict from `dict` buffer.\n  Decompression will have to use same dictionary.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special: Loading a NULL (or 0-size) dictionary invalidates previous dictionary,\n           meaning \"return to no-dictionary mode\".\n  Note 1 : Dictionary is sticky, it will be used for all future compressed frames,\n           until parameters are reset, a new dictionary is loaded, or the dictionary\n           is explicitly invalidated by loading a NULL dictionary.\n  Note 2 : Loading a dictionary involves building tables.\n           It's also a CPU consuming operation, with non-negligible impact on latency.\n           Tables are dependent on compression parameters, and for this reason,\n           compression parameters can no longer be changed after loading a dictionary.\n  Note 3 :`dict` content will be copied internally.\n           Use experimental ZSTD_CCtx_loadDictionary_byReference() to reference content instead.\n           In such a case, dictionary buffer must outlive its users.\n  Note 4 : Use ZSTD_CCtx_loadDictionary_advanced()\n           to precisely select how dictionary content must be interpreted.\n  Note 5 : This method does not benefit from LDM (long distance mode).\n           If you want to employ LDM on some large dictionary content,\n           prefer employing ZSTD_CCtx_refPrefix() described below."]
     pub fn ZSTD_CCtx_loadDictionary(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -526,7 +530,7 @@ extern "C" {
     #[doc = " ZSTD_CCtx_refPrefix() : Requires v1.4.0+\n  Reference a prefix (single-usage dictionary) for next compressed frame.\n  A prefix is **only used once**. Tables are discarded at end of frame (ZSTD_e_end).\n  Decompression will need same prefix to properly regenerate data.\n  Compressing with a prefix is similar in outcome as performing a diff and compressing it,\n  but performs much faster, especially during decompression (compression speed is tunable with compression level).\n  This method is compatible with LDM (long distance mode).\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary\n  Note 1 : Prefix buffer is referenced. It **must** outlive compression.\n           Its content must remain unmodified during compression.\n  Note 2 : If the intention is to diff some large src data blob with some prior version of itself,\n           ensure that the window size is large enough to contain the entire source.\n           See ZSTD_c_windowLog.\n  Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.\n           It's a CPU consuming operation, with non-negligible impact on latency.\n           If there is a need to use the same prefix multiple times, consider loadDictionary instead.\n  Note 4 : By default, the prefix is interpreted as raw content (ZSTD_dct_rawContent).\n           Use experimental ZSTD_CCtx_refPrefix_advanced() to alter dictionary interpretation."]
     pub fn ZSTD_CCtx_refPrefix(
         cctx: *mut ZSTD_CCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
     ) -> usize;
 }
@@ -534,7 +538,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_loadDictionary() : Requires v1.4.0+\n  Create an internal DDict from dict buffer, to be used to decompress all future frames.\n  The dictionary remains valid for all future frames, until explicitly invalidated, or\n  a new dictionary is loaded.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special : Adding a NULL (or 0-size) dictionary invalidates any previous dictionary,\n            meaning \"return to no-dictionary mode\".\n  Note 1 : Loading a dictionary involves building tables,\n           which has a non-negligible impact on CPU usage and latency.\n           It's recommended to \"load once, use many times\", to amortize the cost\n  Note 2 :`dict` content will be copied internally, so `dict` can be released after loading.\n           Use ZSTD_DCtx_loadDictionary_byReference() to reference dictionary content instead.\n  Note 3 : Use ZSTD_DCtx_loadDictionary_advanced() to take control of\n           how dictionary content is loaded and interpreted."]
     pub fn ZSTD_DCtx_loadDictionary(
         dctx: *mut ZSTD_DCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -549,7 +553,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_refPrefix() : Requires v1.4.0+\n  Reference a prefix (single-usage dictionary) to decompress next frame.\n  This is the reverse operation of ZSTD_CCtx_refPrefix(),\n  and must use the same prefix as the one used during compression.\n  Prefix is **only used once**. Reference is discarded at end of frame.\n  End of frame is reached when ZSTD_decompressStream() returns 0.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary\n  Note 2 : Prefix buffer is referenced. It **must** outlive decompression.\n           Prefix buffer must remain unmodified up to the end of frame,\n           reached when ZSTD_decompressStream() returns 0.\n  Note 3 : By default, the prefix is treated as raw content (ZSTD_dct_rawContent).\n           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode (Experimental section)\n  Note 4 : Referencing a raw content prefix has almost no cpu nor memory cost.\n           A full dictionary is more costly, as it requires building tables."]
     pub fn ZSTD_DCtx_refPrefix(
         dctx: *mut ZSTD_DCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
     ) -> usize;
 }

--- a/zstd-safe/zstd-sys/src/bindings_zstd_experimental.rs
+++ b/zstd-safe/zstd-sys/src/bindings_zstd_experimental.rs
@@ -77,48 +77,48 @@ pub const ZSTD_TARGETCBLOCKSIZE_MAX: u32 = 131072;
 pub const ZSTD_SRCSIZEHINT_MIN: u32 = 0;
 extern "C" {
     #[doc = " ZSTD_versionNumber() :\n  Return runtime library version, the value is (MAJOR*100*100 + MINOR*100 + RELEASE)."]
-    pub fn ZSTD_versionNumber() -> libc::c_uint;
+    pub fn ZSTD_versionNumber() -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_versionString() :\n  Return runtime library version, like \"1.4.5\". Requires v1.3.0+."]
-    pub fn ZSTD_versionString() -> *const libc::c_char;
+    pub fn ZSTD_versionString() -> *const core::ffi::c_char;
 }
 extern "C" {
     #[doc = "  Simple API\n/\n/*! ZSTD_compress() :\n  Compresses `src` content as a single zstd compressed frame into already allocated `dst`.\n  NOTE: Providing `dstCapacity >= ZSTD_compressBound(srcSize)` guarantees that zstd will have\n        enough space to successfully compress the data.\n  @return : compressed size written into `dst` (<= `dstCapacity),\n            or an error code if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_compress(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_decompress() :\n  `compressedSize` : must be the _exact_ size of some number of compressed and/or skippable frames.\n  `dstCapacity` is an upper bound of originalSize to regenerate.\n  If user cannot imply a maximum upper bound, it's better to use streaming mode to decompress data.\n  @return : the number of bytes decompressed into `dst` (<= `dstCapacity`),\n            or an errorCode if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_decompress(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         compressedSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_getFrameContentSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_getDecompressedSize() :\n  NOTE: This function is now obsolete, in favor of ZSTD_getFrameContentSize().\n  Both functions work the same way, but ZSTD_getDecompressedSize() blends\n  \"empty\", \"unknown\" and \"error\" results to the same return value (0),\n  while ZSTD_getFrameContentSize() gives them separate return values.\n @return : decompressed size of `src` frame content _if known and not empty_, 0 otherwise."]
     pub fn ZSTD_getDecompressedSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_findFrameCompressedSize() : Requires v1.4.0+\n `src` should point to the start of a ZSTD frame or skippable frame.\n `srcSize` must be >= first frame size\n @return : the compressed size of the first frame starting at `src`,\n           suitable to pass as `srcSize` to `ZSTD_decompress` or similar,\n        or an error code if input is invalid"]
     pub fn ZSTD_findFrameCompressedSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -126,19 +126,19 @@ extern "C" {
     pub fn ZSTD_compressBound(srcSize: usize) -> usize;
 }
 extern "C" {
-    pub fn ZSTD_isError(code: usize) -> libc::c_uint;
+    pub fn ZSTD_isError(code: usize) -> core::ffi::c_uint;
 }
 extern "C" {
-    pub fn ZSTD_getErrorName(code: usize) -> *const libc::c_char;
+    pub fn ZSTD_getErrorName(code: usize) -> *const core::ffi::c_char;
 }
 extern "C" {
-    pub fn ZSTD_minCLevel() -> libc::c_int;
+    pub fn ZSTD_minCLevel() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ZSTD_maxCLevel() -> libc::c_int;
+    pub fn ZSTD_maxCLevel() -> core::ffi::c_int;
 }
 extern "C" {
-    pub fn ZSTD_defaultCLevel() -> libc::c_int;
+    pub fn ZSTD_defaultCLevel() -> core::ffi::c_int;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -157,11 +157,11 @@ extern "C" {
     #[doc = " ZSTD_compressCCtx() :\n  Same as ZSTD_compress(), using an explicit ZSTD_CCtx.\n  Important : in order to behave similarly to `ZSTD_compress()`,\n  this function compresses at requested compression level,\n  __ignoring any other parameter__ .\n  If any advanced parameter was set using the advanced API,\n  they will all be reset. Only `compressionLevel` remains."]
     pub fn ZSTD_compressCCtx(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 #[repr(C)]
@@ -180,9 +180,9 @@ extern "C" {
     #[doc = " ZSTD_decompressDCtx() :\n  Same as ZSTD_decompress(),\n  requires an allocated ZSTD_DCtx.\n  Compatible with sticky parameters."]
     pub fn ZSTD_decompressDCtx(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -246,8 +246,8 @@ pub enum ZSTD_cParameter {
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_bounds {
     pub error: usize,
-    pub lowerBound: libc::c_int,
-    pub upperBound: libc::c_int,
+    pub lowerBound: core::ffi::c_int,
+    pub upperBound: core::ffi::c_int,
 }
 extern "C" {
     #[doc = " ZSTD_cParam_getBounds() :\n  All parameters must belong to an interval with lower and upper bounds,\n  otherwise they will either trigger an error or be automatically clamped.\n @return : a structure, ZSTD_bounds, which contains\n         - an error status field, which must be tested using ZSTD_isError()\n         - lower and upper bounds, both inclusive"]
@@ -258,14 +258,14 @@ extern "C" {
     pub fn ZSTD_CCtx_setParameter(
         cctx: *mut ZSTD_CCtx,
         param: ZSTD_cParameter,
-        value: libc::c_int,
+        value: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_CCtx_setPledgedSrcSize() :\n  Total input data size to be compressed as a single frame.\n  Value will be written in frame header, unless if explicitly forbidden using ZSTD_c_contentSizeFlag.\n  This value will also be controlled at end of frame, and trigger an error if not respected.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Note 1 : pledgedSrcSize==0 actually means zero, aka an empty frame.\n           In order to mean \"unknown content size\", pass constant ZSTD_CONTENTSIZE_UNKNOWN.\n           ZSTD_CONTENTSIZE_UNKNOWN is default value for any new frame.\n  Note 2 : pledgedSrcSize is only valid once, for the next frame.\n           It's discarded at the end of the frame, and replaced by ZSTD_CONTENTSIZE_UNKNOWN.\n  Note 3 : Whenever all input data is provided and consumed in a single round,\n           for example with ZSTD_compress2(),\n           or invoking immediately ZSTD_compressStream2(,,,ZSTD_e_end),\n           this value is automatically overridden by srcSize instead."]
     pub fn ZSTD_CCtx_setPledgedSrcSize(
         cctx: *mut ZSTD_CCtx,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 #[repr(u32)]
@@ -286,9 +286,9 @@ extern "C" {
     #[doc = " ZSTD_compress2() :\n  Behave the same as ZSTD_compressCCtx(), but compression parameters are set using the advanced API.\n  ZSTD_compress2() always starts a new frame.\n  Should cctx hold data from a previously unfinished frame, everything about it is forgotten.\n  - Compression parameters are pushed into CCtx before starting compression, using ZSTD_CCtx_set*()\n  - The function is always blocking, returns when compression is completed.\n  NOTE: Providing `dstCapacity >= ZSTD_compressBound(srcSize)` guarantees that zstd will have\n        enough space to successfully compress the data, though it is possible it fails for other reasons.\n @return : compressed size written into `dst` (<= `dstCapacity),\n           or an error code if it fails (which can be tested using ZSTD_isError())."]
     pub fn ZSTD_compress2(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -312,7 +312,7 @@ extern "C" {
     pub fn ZSTD_DCtx_setParameter(
         dctx: *mut ZSTD_DCtx,
         param: ZSTD_dParameter,
-        value: libc::c_int,
+        value: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -327,7 +327,7 @@ extern "C" {
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_inBuffer_s {
     #[doc = "< start of input buffer"]
-    pub src: *const libc::c_void,
+    pub src: *const core::ffi::c_void,
     #[doc = "< size of input buffer"]
     pub size: usize,
     #[doc = "< position where reading stopped. Will be updated. Necessarily 0 <= pos <= size"]
@@ -339,7 +339,7 @@ pub type ZSTD_inBuffer = ZSTD_inBuffer_s;
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_outBuffer_s {
     #[doc = "< start of output buffer"]
-    pub dst: *mut libc::c_void,
+    pub dst: *mut core::ffi::c_void,
     #[doc = "< size of output buffer"]
     pub size: usize,
     #[doc = "< position where writing stopped. Will be updated. Necessarily 0 <= pos <= size"]
@@ -379,7 +379,7 @@ extern "C" {
     #[doc = " Equivalent to:\n\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_refCDict(zcs, NULL); // clear the dictionary (if any)\n     ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);\n\n Note that ZSTD_initCStream() clears any previously set dictionary. Use the new API\n to compress with a dictionary."]
     pub fn ZSTD_initCStream(
         zcs: *mut ZSTD_CStream,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -433,24 +433,24 @@ extern "C" {
     #[doc = "  Simple dictionary API\n/\n/*! ZSTD_compress_usingDict() :\n  Compression at an explicit compression level using a Dictionary.\n  A dictionary can be any arbitrary data segment (also called a prefix),\n  or a buffer with specified information (see zdict.h).\n  Note : This function loads the dictionary, resulting in significant startup delay.\n         It's intended for a dictionary used only once.\n  Note 2 : When `dict == NULL || dictSize < 8` no dictionary is used."]
     pub fn ZSTD_compress_usingDict(
         ctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_decompress_usingDict() :\n  Decompression using a known Dictionary.\n  Dictionary must be identical to the one used during compression.\n  Note : This function loads the dictionary, resulting in significant startup delay.\n         It's intended for a dictionary used only once.\n  Note : When `dict == NULL || dictSize < 8` no dictionary is used."]
     pub fn ZSTD_decompress_usingDict(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -464,9 +464,9 @@ pub type ZSTD_CDict = ZSTD_CDict_s;
 extern "C" {
     #[doc = " ZSTD_createCDict() :\n  When compressing multiple messages or blocks using the same dictionary,\n  it's recommended to digest the dictionary only once, since it's a costly operation.\n  ZSTD_createCDict() will create a state from digesting a dictionary.\n  The resulting state can be used for future compression operations with very limited startup cost.\n  ZSTD_CDict can be created once and shared by multiple threads concurrently, since its usage is read-only.\n @dictBuffer can be released after ZSTD_CDict creation, because its content is copied within CDict.\n  Note 1 : Consider experimental function `ZSTD_createCDict_byReference()` if you prefer to not duplicate @dictBuffer content.\n  Note 2 : A ZSTD_CDict can be created from an empty @dictBuffer,\n      in which case the only thing that it transports is the @compressionLevel.\n      This can be useful in a pipeline featuring ZSTD_compress_usingCDict() exclusively,\n      expecting a ZSTD_CDict parameter with any data, including those without a known dictionary."]
     pub fn ZSTD_createCDict(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> *mut ZSTD_CDict;
 }
 extern "C" {
@@ -477,9 +477,9 @@ extern "C" {
     #[doc = " ZSTD_compress_usingCDict() :\n  Compression using a digested Dictionary.\n  Recommended when same dictionary is used multiple times.\n  Note : compression level is _decided at dictionary creation time_,\n     and frame parameters are hardcoded (dictID=yes, contentSize=yes, checksum=no)"]
     pub fn ZSTD_compress_usingCDict(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         cdict: *const ZSTD_CDict,
     ) -> usize;
@@ -493,7 +493,7 @@ pub type ZSTD_DDict = ZSTD_DDict_s;
 extern "C" {
     #[doc = " ZSTD_createDDict() :\n  Create a digested dictionary, ready to start decompression operation without startup delay.\n  dictBuffer can be released after DDict creation, as its content is copied inside DDict."]
     pub fn ZSTD_createDDict(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
     ) -> *mut ZSTD_DDict;
 }
@@ -505,9 +505,9 @@ extern "C" {
     #[doc = " ZSTD_decompress_usingDDict() :\n  Decompression using a digested Dictionary.\n  Recommended when same dictionary is used multiple times."]
     pub fn ZSTD_decompress_usingDDict(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         ddict: *const ZSTD_DDict,
     ) -> usize;
@@ -515,30 +515,34 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_getDictID_fromDict() : Requires v1.4.0+\n  Provides the dictID stored within dictionary.\n  if @return == 0, the dictionary is not conformant with Zstandard specification.\n  It can still be loaded, but as a content-only dictionary."]
     pub fn ZSTD_getDictID_fromDict(
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromCDict() : Requires v1.5.0+\n  Provides the dictID of the dictionary loaded into `cdict`.\n  If @return == 0, the dictionary is not conformant to Zstandard specification, or empty.\n  Non-conformant dictionaries can still be loaded, but as content-only dictionaries."]
-    pub fn ZSTD_getDictID_fromCDict(cdict: *const ZSTD_CDict) -> libc::c_uint;
+    pub fn ZSTD_getDictID_fromCDict(
+        cdict: *const ZSTD_CDict,
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromDDict() : Requires v1.4.0+\n  Provides the dictID of the dictionary loaded into `ddict`.\n  If @return == 0, the dictionary is not conformant to Zstandard specification, or empty.\n  Non-conformant dictionaries can still be loaded, but as content-only dictionaries."]
-    pub fn ZSTD_getDictID_fromDDict(ddict: *const ZSTD_DDict) -> libc::c_uint;
+    pub fn ZSTD_getDictID_fromDDict(
+        ddict: *const ZSTD_DDict,
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_getDictID_fromFrame() : Requires v1.4.0+\n  Provides the dictID required to decompressed the frame stored within `src`.\n  If @return == 0, the dictID could not be decoded.\n  This could for one of the following reasons :\n  - The frame does not require a dictionary to be decoded (most common case).\n  - The frame was built with dictID intentionally removed. Whatever dictionary is necessary is a hidden piece of information.\n    Note : this use case also happens when using a non-conformant dictionary.\n  - `srcSize` is too small, and as a result, the frame header could not be decoded (only possible if `srcSize < ZSTD_FRAMEHEADERSIZE_MAX`).\n  - This is not a Zstandard frame.\n  When identifying the exact failure cause, it's possible to use ZSTD_getFrameHeader(), which will provide a more precise error code."]
     pub fn ZSTD_getDictID_fromFrame(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_CCtx_loadDictionary() : Requires v1.4.0+\n  Create an internal CDict from `dict` buffer.\n  Decompression will have to use same dictionary.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special: Loading a NULL (or 0-size) dictionary invalidates previous dictionary,\n           meaning \"return to no-dictionary mode\".\n  Note 1 : Dictionary is sticky, it will be used for all future compressed frames,\n           until parameters are reset, a new dictionary is loaded, or the dictionary\n           is explicitly invalidated by loading a NULL dictionary.\n  Note 2 : Loading a dictionary involves building tables.\n           It's also a CPU consuming operation, with non-negligible impact on latency.\n           Tables are dependent on compression parameters, and for this reason,\n           compression parameters can no longer be changed after loading a dictionary.\n  Note 3 :`dict` content will be copied internally.\n           Use experimental ZSTD_CCtx_loadDictionary_byReference() to reference content instead.\n           In such a case, dictionary buffer must outlive its users.\n  Note 4 : Use ZSTD_CCtx_loadDictionary_advanced()\n           to precisely select how dictionary content must be interpreted.\n  Note 5 : This method does not benefit from LDM (long distance mode).\n           If you want to employ LDM on some large dictionary content,\n           prefer employing ZSTD_CCtx_refPrefix() described below."]
     pub fn ZSTD_CCtx_loadDictionary(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -553,7 +557,7 @@ extern "C" {
     #[doc = " ZSTD_CCtx_refPrefix() : Requires v1.4.0+\n  Reference a prefix (single-usage dictionary) for next compressed frame.\n  A prefix is **only used once**. Tables are discarded at end of frame (ZSTD_e_end).\n  Decompression will need same prefix to properly regenerate data.\n  Compressing with a prefix is similar in outcome as performing a diff and compressing it,\n  but performs much faster, especially during decompression (compression speed is tunable with compression level).\n  This method is compatible with LDM (long distance mode).\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special: Adding any prefix (including NULL) invalidates any previous prefix or dictionary\n  Note 1 : Prefix buffer is referenced. It **must** outlive compression.\n           Its content must remain unmodified during compression.\n  Note 2 : If the intention is to diff some large src data blob with some prior version of itself,\n           ensure that the window size is large enough to contain the entire source.\n           See ZSTD_c_windowLog.\n  Note 3 : Referencing a prefix involves building tables, which are dependent on compression parameters.\n           It's a CPU consuming operation, with non-negligible impact on latency.\n           If there is a need to use the same prefix multiple times, consider loadDictionary instead.\n  Note 4 : By default, the prefix is interpreted as raw content (ZSTD_dct_rawContent).\n           Use experimental ZSTD_CCtx_refPrefix_advanced() to alter dictionary interpretation."]
     pub fn ZSTD_CCtx_refPrefix(
         cctx: *mut ZSTD_CCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
     ) -> usize;
 }
@@ -561,7 +565,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_loadDictionary() : Requires v1.4.0+\n  Create an internal DDict from dict buffer, to be used to decompress all future frames.\n  The dictionary remains valid for all future frames, until explicitly invalidated, or\n  a new dictionary is loaded.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Special : Adding a NULL (or 0-size) dictionary invalidates any previous dictionary,\n            meaning \"return to no-dictionary mode\".\n  Note 1 : Loading a dictionary involves building tables,\n           which has a non-negligible impact on CPU usage and latency.\n           It's recommended to \"load once, use many times\", to amortize the cost\n  Note 2 :`dict` content will be copied internally, so `dict` can be released after loading.\n           Use ZSTD_DCtx_loadDictionary_byReference() to reference dictionary content instead.\n  Note 3 : Use ZSTD_DCtx_loadDictionary_advanced() to take control of\n           how dictionary content is loaded and interpreted."]
     pub fn ZSTD_DCtx_loadDictionary(
         dctx: *mut ZSTD_DCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -576,7 +580,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_refPrefix() : Requires v1.4.0+\n  Reference a prefix (single-usage dictionary) to decompress next frame.\n  This is the reverse operation of ZSTD_CCtx_refPrefix(),\n  and must use the same prefix as the one used during compression.\n  Prefix is **only used once**. Reference is discarded at end of frame.\n  End of frame is reached when ZSTD_decompressStream() returns 0.\n @result : 0, or an error code (which can be tested with ZSTD_isError()).\n  Note 1 : Adding any prefix (including NULL) invalidates any previously set prefix or dictionary\n  Note 2 : Prefix buffer is referenced. It **must** outlive decompression.\n           Prefix buffer must remain unmodified up to the end of frame,\n           reached when ZSTD_decompressStream() returns 0.\n  Note 3 : By default, the prefix is treated as raw content (ZSTD_dct_rawContent).\n           Use ZSTD_CCtx_refPrefix_advanced() to alter dictMode (Experimental section)\n  Note 4 : Referencing a raw content prefix has almost no cpu nor memory cost.\n           A full dictionary is more costly, as it requires building tables."]
     pub fn ZSTD_DCtx_refPrefix(
         dctx: *mut ZSTD_DCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
     ) -> usize;
 }
@@ -608,26 +612,26 @@ pub type ZSTD_CCtx_params = ZSTD_CCtx_params_s;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_Sequence {
-    pub offset: libc::c_uint,
-    pub litLength: libc::c_uint,
-    pub matchLength: libc::c_uint,
-    pub rep: libc::c_uint,
+    pub offset: core::ffi::c_uint,
+    pub litLength: core::ffi::c_uint,
+    pub matchLength: core::ffi::c_uint,
+    pub rep: core::ffi::c_uint,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_compressionParameters {
     #[doc = "< largest match distance : larger == more compression, more memory needed during decompression"]
-    pub windowLog: libc::c_uint,
+    pub windowLog: core::ffi::c_uint,
     #[doc = "< fully searched segment : larger == more compression, slower, more memory (useless for fast)"]
-    pub chainLog: libc::c_uint,
+    pub chainLog: core::ffi::c_uint,
     #[doc = "< dispatch table : larger == faster, more memory"]
-    pub hashLog: libc::c_uint,
+    pub hashLog: core::ffi::c_uint,
     #[doc = "< nb of searches : larger == more compression, slower"]
-    pub searchLog: libc::c_uint,
+    pub searchLog: core::ffi::c_uint,
     #[doc = "< match length searched : larger == faster decompression, sometimes less compression"]
-    pub minMatch: libc::c_uint,
+    pub minMatch: core::ffi::c_uint,
     #[doc = "< acceptable match size for optimal parser (only) : larger == more compression, slower"]
-    pub targetLength: libc::c_uint,
+    pub targetLength: core::ffi::c_uint,
     #[doc = "< see ZSTD_strategy definition above"]
     pub strategy: ZSTD_strategy,
 }
@@ -635,11 +639,11 @@ pub struct ZSTD_compressionParameters {
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_frameParameters {
     #[doc = "< 1: content size will be in frame header (when known)"]
-    pub contentSizeFlag: libc::c_int,
+    pub contentSizeFlag: core::ffi::c_int,
     #[doc = "< 1: generate a 32-bits checksum using XXH64 algorithm at end of frame, for error detection"]
-    pub checksumFlag: libc::c_int,
+    pub checksumFlag: core::ffi::c_int,
     #[doc = "< 1: no dictID will be saved into frame header (dictID is only useful for dictionary compression)"]
-    pub noDictIDFlag: libc::c_int,
+    pub noDictIDFlag: core::ffi::c_int,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -708,21 +712,21 @@ pub enum ZSTD_paramSwitch_e {
 extern "C" {
     #[doc = " ZSTD_findDecompressedSize() :\n  `src` should point to the start of a series of ZSTD encoded and/or skippable frames\n  `srcSize` must be the _exact_ size of this series\n       (i.e. there should be a frame boundary at `src + srcSize`)\n  @return : - decompressed size of all data in all successive frames\n            - if the decompressed size cannot be determined: ZSTD_CONTENTSIZE_UNKNOWN\n            - if an error occurred: ZSTD_CONTENTSIZE_ERROR\n\n   note 1 : decompressed size is an optional field, that may not be present, especially in streaming mode.\n            When `return==ZSTD_CONTENTSIZE_UNKNOWN`, data to decompress could be any size.\n            In which case, it's necessary to use streaming mode to decompress data.\n   note 2 : decompressed size is always present when compression is done with ZSTD_compress()\n   note 3 : decompressed size can be very large (64-bits value),\n            potentially larger than what local system can handle as a single memory segment.\n            In which case, it's necessary to use streaming mode to decompress data.\n   note 4 : If source is untrusted, decompressed size could be wrong or intentionally modified.\n            Always ensure result fits within application's authorized limits.\n            Each application can set its own limits.\n   note 5 : ZSTD_findDecompressedSize handles multiple frames, and so it must traverse the input to\n            read each contained frame header.  This is fast as most of the data is skipped,\n            however it does mean that all frame data must be present and valid."]
     pub fn ZSTD_findDecompressedSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_decompressBound() :\n  `src` should point to the start of a series of ZSTD encoded and/or skippable frames\n  `srcSize` must be the _exact_ size of this series\n       (i.e. there should be a frame boundary at `src + srcSize`)\n  @return : - upper-bound for the decompressed size of all data in all successive frames\n            - if an error occurred: ZSTD_CONTENTSIZE_ERROR\n\n  note 1  : an error can occur if `src` contains an invalid or incorrectly formatted frame.\n  note 2  : the upper-bound is exact when the decompressed size field is available in every ZSTD encoded frame of `src`.\n            in this case, `ZSTD_findDecompressedSize` and `ZSTD_decompressBound` return the same value.\n  note 3  : when the decompressed size field isn't available, the upper-bound for that frame is calculated by:\n              upper-bound = # blocks * min(128 KB, Window_Size)"]
     pub fn ZSTD_decompressBound(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-    ) -> libc::c_ulonglong;
+    ) -> core::ffi::c_ulonglong;
 }
 extern "C" {
     #[doc = " ZSTD_frameHeaderSize() :\n  srcSize must be >= ZSTD_FRAMEHEADERSIZE_PREFIX.\n @return : size of the Frame Header,\n           or an error code (if srcSize is too small)"]
     pub fn ZSTD_frameHeaderSize(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -735,21 +739,21 @@ pub enum ZSTD_frameType_e {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_frameHeader {
-    pub frameContentSize: libc::c_ulonglong,
-    pub windowSize: libc::c_ulonglong,
-    pub blockSizeMax: libc::c_uint,
+    pub frameContentSize: core::ffi::c_ulonglong,
+    pub windowSize: core::ffi::c_ulonglong,
+    pub blockSizeMax: core::ffi::c_uint,
     pub frameType: ZSTD_frameType_e,
-    pub headerSize: libc::c_uint,
-    pub dictID: libc::c_uint,
-    pub checksumFlag: libc::c_uint,
-    pub _reserved1: libc::c_uint,
-    pub _reserved2: libc::c_uint,
+    pub headerSize: core::ffi::c_uint,
+    pub dictID: core::ffi::c_uint,
+    pub checksumFlag: core::ffi::c_uint,
+    pub _reserved1: core::ffi::c_uint,
+    pub _reserved2: core::ffi::c_uint,
 }
 extern "C" {
     #[doc = " ZSTD_getFrameHeader() :\n  decode Frame Header, or requires larger `srcSize`.\n @return : 0, `zfhPtr` is correctly filled,\n          >0, `srcSize` is too small, value is wanted `srcSize` amount,\n           or an error code, which can be tested using ZSTD_isError()"]
     pub fn ZSTD_getFrameHeader(
         zfhPtr: *mut ZSTD_frameHeader,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -757,7 +761,7 @@ extern "C" {
     #[doc = " ZSTD_getFrameHeader_advanced() :\n  same as ZSTD_getFrameHeader(),\n  with added capability to select a format (like ZSTD_f_zstd1_magicless)"]
     pub fn ZSTD_getFrameHeader_advanced(
         zfhPtr: *mut ZSTD_frameHeader,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         format: ZSTD_format_e,
     ) -> usize;
@@ -765,7 +769,7 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_decompressionMargin() :\n Zstd supports in-place decompression, where the input and output buffers overlap.\n In this case, the output buffer must be at least (Margin + Output_Size) bytes large,\n and the input buffer must be at the end of the output buffer.\n\n  _______________________ Output Buffer ________________________\n |                                                              |\n |                                        ____ Input Buffer ____|\n |                                       |                      |\n v                                       v                      v\n |---------------------------------------|-----------|----------|\n ^                                                   ^          ^\n |___________________ Output_Size ___________________|_ Margin _|\n\n NOTE: See also ZSTD_DECOMPRESSION_MARGIN().\n NOTE: This applies only to single-pass decompression through ZSTD_decompress() or\n ZSTD_decompressDCtx().\n NOTE: This function supports multi-frame input.\n\n @param src The compressed frame(s)\n @param srcSize The size of the compressed frame(s)\n @returns The decompression margin or an error that can be checked with ZSTD_isError()."]
     pub fn ZSTD_decompressionMargin(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -785,7 +789,7 @@ extern "C" {
         zc: *mut ZSTD_CCtx,
         outSeqs: *mut ZSTD_Sequence,
         outSeqsSize: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -800,44 +804,44 @@ extern "C" {
     #[doc = " ZSTD_compressSequences() :\n Compress an array of ZSTD_Sequence, associated with @src buffer, into dst.\n @src contains the entire input (not just the literals).\n If @srcSize > sum(sequence.length), the remaining bytes are considered all literals\n If a dictionary is included, then the cctx should reference the dict. (see: ZSTD_CCtx_refCDict(), ZSTD_CCtx_loadDictionary(), etc.)\n The entire source is compressed into a single frame.\n\n The compression behavior changes based on cctx params. In particular:\n    If ZSTD_c_blockDelimiters == ZSTD_sf_noBlockDelimiters, the array of ZSTD_Sequence is expected to contain\n    no block delimiters (defined in ZSTD_Sequence). Block boundaries are roughly determined based on\n    the block size derived from the cctx, and sequences may be split. This is the default setting.\n\n    If ZSTD_c_blockDelimiters == ZSTD_sf_explicitBlockDelimiters, the array of ZSTD_Sequence is expected to contain\n    block delimiters (defined in ZSTD_Sequence). Behavior is undefined if no block delimiters are provided.\n\n    If ZSTD_c_validateSequences == 0, this function will blindly accept the sequences provided. Invalid sequences cause undefined\n    behavior. If ZSTD_c_validateSequences == 1, then if sequence is invalid (see doc/zstd_compression_format.md for\n    specifics regarding offset/matchlength requirements) then the function will bail out and return an error.\n\n    In addition to the two adjustable experimental params, there are other important cctx params.\n    - ZSTD_c_minMatch MUST be set as less than or equal to the smallest match generated by the match finder. It has a minimum value of ZSTD_MINMATCH_MIN.\n    - ZSTD_c_compressionLevel accordingly adjusts the strength of the entropy coder, as it would in typical compression.\n    - ZSTD_c_windowLog affects offset validation: this function will return an error at higher debug levels if a provided offset\n      is larger than what the spec allows for a given window log and dictionary (if present). See: doc/zstd_compression_format.md\n\n Note: Repcodes are, as of now, always re-calculated within this function, so ZSTD_Sequence::rep is unused.\n Note 2: Once we integrate ability to ingest repcodes, the explicit block delims mode must respect those repcodes exactly,\n         and cannot emit an RLE block that disagrees with the repcode history\n @return : final compressed size, or a ZSTD error code."]
     pub fn ZSTD_compressSequences(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstSize: usize,
         inSeqs: *const ZSTD_Sequence,
         inSeqsSize: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_writeSkippableFrame() :\n Generates a zstd skippable frame containing data given by src, and writes it to dst buffer.\n\n Skippable frames begin with a 4-byte magic number. There are 16 possible choices of magic number,\n ranging from ZSTD_MAGIC_SKIPPABLE_START to ZSTD_MAGIC_SKIPPABLE_START+15.\n As such, the parameter magicVariant controls the exact skippable frame magic number variant used, so\n the magic number used will be ZSTD_MAGIC_SKIPPABLE_START + magicVariant.\n\n Returns an error if destination buffer is not large enough, if the source size is not representable\n with a 4-byte unsigned int, or if the parameter magicVariant is greater than 15 (and therefore invalid).\n\n @return : number of bytes written or a ZSTD error."]
     pub fn ZSTD_writeSkippableFrame(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        magicVariant: libc::c_uint,
+        magicVariant: core::ffi::c_uint,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_readSkippableFrame() :\n Retrieves a zstd skippable frame containing data given by src, and writes it to dst buffer.\n\n The parameter magicVariant will receive the magicVariant that was supplied when the frame was written,\n i.e. magicNumber - ZSTD_MAGIC_SKIPPABLE_START.  This can be NULL if the caller is not interested\n in the magicVariant.\n\n Returns an error if destination buffer is not large enough, or if the frame is not skippable.\n\n @return : number of bytes written or a ZSTD error."]
     pub fn ZSTD_readSkippableFrame(
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        magicVariant: *mut libc::c_uint,
-        src: *const libc::c_void,
+        magicVariant: *mut core::ffi::c_uint,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_isSkippableFrame() :\n  Tells if the content of `buffer` starts with a valid Frame Identifier for a skippable frame."]
     pub fn ZSTD_isSkippableFrame(
-        buffer: *const libc::c_void,
+        buffer: *const core::ffi::c_void,
         size: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_estimate*() :\n  These functions make it possible to estimate memory usage\n  of a future {D,C}Ctx, before its creation.\n\n  ZSTD_estimateCCtxSize() will provide a memory budget large enough\n  for any compression level up to selected one.\n  Note : Unlike ZSTD_estimateCStreamSize*(), this estimate\n         does not include space for a window buffer.\n         Therefore, the estimation is only guaranteed for single-shot compressions, not streaming.\n  The estimate will assume the input may be arbitrarily large,\n  which is the worst case.\n\n  When srcSize can be bound by a known and rather \"small\" value,\n  this fact can be used to provide a tighter estimation\n  because the CCtx compression context will need less memory.\n  This tighter estimation can be provided by more advanced functions\n  ZSTD_estimateCCtxSize_usingCParams(), which can be used in tandem with ZSTD_getCParams(),\n  and ZSTD_estimateCCtxSize_usingCCtxParams(), which can be used in tandem with ZSTD_CCtxParams_setParameter().\n  Both can be used to estimate memory using custom compression parameters and arbitrary srcSize limits.\n\n  Note : only single-threaded compression is supported.\n  ZSTD_estimateCCtxSize_usingCCtxParams() will return an error code if ZSTD_c_nbWorkers is >= 1.\n\n  Note 2 : ZSTD_estimateCCtxSize* functions are not compatible with the Block-Level Sequence Producer API at this time.\n  Size estimates assume that no external sequence producer is registered."]
-    pub fn ZSTD_estimateCCtxSize(compressionLevel: libc::c_int) -> usize;
+    pub fn ZSTD_estimateCCtxSize(compressionLevel: core::ffi::c_int) -> usize;
 }
 extern "C" {
     pub fn ZSTD_estimateCCtxSize_usingCParams(
@@ -854,7 +858,9 @@ extern "C" {
 }
 extern "C" {
     #[doc = " ZSTD_estimateCStreamSize() :\n  ZSTD_estimateCStreamSize() will provide a budget large enough for any compression level up to selected one.\n  It will also consider src size to be arbitrarily \"large\", which is worst case.\n  If srcSize is known to always be small, ZSTD_estimateCStreamSize_usingCParams() can provide a tighter estimation.\n  ZSTD_estimateCStreamSize_usingCParams() can be used in tandem with ZSTD_getCParams() to create cParams from compressionLevel.\n  ZSTD_estimateCStreamSize_usingCCtxParams() can be used in tandem with ZSTD_CCtxParams_setParameter(). Only single-threaded compression is supported. This function will return an error code if ZSTD_c_nbWorkers is >= 1.\n  Note : CStream size estimation is only correct for single-threaded compression.\n  ZSTD_DStream memory budget depends on window Size.\n  This information can be passed manually, using ZSTD_estimateDStreamSize,\n  or deducted from a valid frame Header, using ZSTD_estimateDStreamSize_fromFrame();\n  Note : if streaming is init with function ZSTD_init?Stream_usingDict(),\n         an internal ?Dict will be created, which additional size is not estimated here.\n         In this case, get total size by adding ZSTD_estimate?DictSize\n  Note 2 : only single-threaded compression is supported.\n  ZSTD_estimateCStreamSize_usingCCtxParams() will return an error code if ZSTD_c_nbWorkers is >= 1.\n  Note 3 : ZSTD_estimateCStreamSize* functions are not compatible with the Block-Level Sequence Producer API at this time.\n  Size estimates assume that no external sequence producer is registered."]
-    pub fn ZSTD_estimateCStreamSize(compressionLevel: libc::c_int) -> usize;
+    pub fn ZSTD_estimateCStreamSize(
+        compressionLevel: core::ffi::c_int,
+    ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_estimateCStreamSize_usingCParams(
@@ -871,7 +877,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ZSTD_estimateDStreamSize_fromFrame(
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -879,7 +885,7 @@ extern "C" {
     #[doc = " ZSTD_estimate?DictSize() :\n  ZSTD_estimateCDictSize() will bet that src size is relatively \"small\", and content is copied, like ZSTD_createCDict().\n  ZSTD_estimateCDictSize_advanced() makes it possible to control compression parameters precisely, like ZSTD_createCDict_advanced().\n  Note : dictionaries created by reference (`ZSTD_dlm_byRef`) are logically smaller."]
     pub fn ZSTD_estimateCDictSize(
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -898,33 +904,33 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_initStatic*() :\n  Initialize an object using a pre-allocated fixed-size buffer.\n  workspace: The memory area to emplace the object into.\n             Provided pointer *must be 8-bytes aligned*.\n             Buffer must outlive object.\n  workspaceSize: Use ZSTD_estimate*Size() to determine\n                 how large workspace must be to support target scenario.\n @return : pointer to object (same address as workspace, just different type),\n           or NULL if error (size too small, incorrect alignment, etc.)\n  Note : zstd will never resize nor malloc() when using a static buffer.\n         If the object requires more memory than available,\n         zstd will just error out (typically ZSTD_error_memory_allocation).\n  Note 2 : there is no corresponding \"free\" function.\n           Since workspace is allocated externally, it must be freed externally too.\n  Note 3 : cParams : use ZSTD_getCParams() to convert a compression level\n           into its associated cParams.\n  Limitation 1 : currently not compatible with internal dictionary creation, triggered by\n                 ZSTD_CCtx_loadDictionary(), ZSTD_initCStream_usingDict() or ZSTD_initDStream_usingDict().\n  Limitation 2 : static cctx currently not compatible with multi-threading.\n  Limitation 3 : static dctx is incompatible with legacy support."]
     pub fn ZSTD_initStaticCCtx(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
     ) -> *mut ZSTD_CCtx;
 }
 extern "C" {
     pub fn ZSTD_initStaticCStream(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
     ) -> *mut ZSTD_CStream;
 }
 extern "C" {
     pub fn ZSTD_initStaticDCtx(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
     ) -> *mut ZSTD_DCtx;
 }
 extern "C" {
     pub fn ZSTD_initStaticDStream(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
     ) -> *mut ZSTD_DStream;
 }
 extern "C" {
     pub fn ZSTD_initStaticCDict(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -933,9 +939,9 @@ extern "C" {
 }
 extern "C" {
     pub fn ZSTD_initStaticDDict(
-        workspace: *mut libc::c_void,
+        workspace: *mut core::ffi::c_void,
         workspaceSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -944,14 +950,14 @@ extern "C" {
 #[doc = " Custom memory allocation :\n  These prototypes make it possible to pass your own allocation/free functions.\n  ZSTD_customMem is provided at creation time, using ZSTD_create*_advanced() variants listed below.\n  All allocation/free operations will be completed using these custom variants instead of regular <stdlib.h> ones."]
 pub type ZSTD_allocFunction = ::core::option::Option<
     unsafe extern "C" fn(
-        opaque: *mut libc::c_void,
+        opaque: *mut core::ffi::c_void,
         size: usize,
-    ) -> *mut libc::c_void,
+    ) -> *mut core::ffi::c_void,
 >;
 pub type ZSTD_freeFunction = ::core::option::Option<
     unsafe extern "C" fn(
-        opaque: *mut libc::c_void,
-        address: *mut libc::c_void,
+        opaque: *mut core::ffi::c_void,
+        address: *mut core::ffi::c_void,
     ),
 >;
 #[repr(C)]
@@ -959,7 +965,7 @@ pub type ZSTD_freeFunction = ::core::option::Option<
 pub struct ZSTD_customMem {
     pub customAlloc: ZSTD_allocFunction,
     pub customFree: ZSTD_freeFunction,
-    pub opaque: *mut libc::c_void,
+    pub opaque: *mut core::ffi::c_void,
 }
 extern "C" {
     #[doc = "< this constant defers to stdlib's functions"]
@@ -987,7 +993,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ZSTD_createCDict_advanced(
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -1016,7 +1022,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ZSTD_createCDict_advanced2(
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -1026,7 +1032,7 @@ extern "C" {
 }
 extern "C" {
     pub fn ZSTD_createDDict_advanced(
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -1036,24 +1042,24 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_createCDict_byReference() :\n  Create a digested dictionary for compression\n  Dictionary content is just referenced, not duplicated.\n  As a consequence, `dictBuffer` **must** outlive CDict,\n  and its content must remain unmodified throughout the lifetime of CDict.\n  note: equivalent to ZSTD_createCDict_advanced(), with dictLoadMethod==ZSTD_dlm_byRef"]
     pub fn ZSTD_createCDict_byReference(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> *mut ZSTD_CDict;
 }
 extern "C" {
     #[doc = " ZSTD_getCParams() :\n @return ZSTD_compressionParameters structure for a selected compression level and estimated srcSize.\n `estimatedSrcSize` value is optional, select 0 if not known"]
     pub fn ZSTD_getCParams(
-        compressionLevel: libc::c_int,
-        estimatedSrcSize: libc::c_ulonglong,
+        compressionLevel: core::ffi::c_int,
+        estimatedSrcSize: core::ffi::c_ulonglong,
         dictSize: usize,
     ) -> ZSTD_compressionParameters;
 }
 extern "C" {
     #[doc = " ZSTD_getParams() :\n  same as ZSTD_getCParams(), but @return a full `ZSTD_parameters` object instead of sub-component `ZSTD_compressionParameters`.\n  All fields of `ZSTD_frameParameters` are set to default : contentSize=1, checksum=0, noDictID=0"]
     pub fn ZSTD_getParams(
-        compressionLevel: libc::c_int,
-        estimatedSrcSize: libc::c_ulonglong,
+        compressionLevel: core::ffi::c_int,
+        estimatedSrcSize: core::ffi::c_ulonglong,
         dictSize: usize,
     ) -> ZSTD_parameters;
 }
@@ -1065,7 +1071,7 @@ extern "C" {
     #[doc = " ZSTD_adjustCParams() :\n  optimize params for a given `srcSize` and `dictSize`.\n `srcSize` can be unknown, in which case use ZSTD_CONTENTSIZE_UNKNOWN.\n `dictSize` must be `0` when there is no dictionary.\n  cPar can be invalid : all parameters will be clamped within valid range in the @return struct.\n  This function never fails (wide contract)"]
     pub fn ZSTD_adjustCParams(
         cPar: ZSTD_compressionParameters,
-        srcSize: libc::c_ulonglong,
+        srcSize: core::ffi::c_ulonglong,
         dictSize: usize,
     ) -> ZSTD_compressionParameters;
 }
@@ -1094,11 +1100,11 @@ extern "C" {
     #[doc = " ZSTD_compress_advanced() :\n  Note : this function is now DEPRECATED.\n         It can be replaced by ZSTD_compress2(), in combination with ZSTD_CCtx_setParameter() and other parameter setters.\n  This prototype will generate compilation warnings."]
     pub fn ZSTD_compress_advanced(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         params: ZSTD_parameters,
     ) -> usize;
@@ -1107,9 +1113,9 @@ extern "C" {
     #[doc = " ZSTD_compress_usingCDict_advanced() :\n  Note : this function is now DEPRECATED.\n         It can be replaced by ZSTD_compress2(), in combination with ZSTD_CCtx_loadDictionary() and other parameter setters.\n  This prototype will generate compilation warnings."]
     pub fn ZSTD_compress_usingCDict_advanced(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         cdict: *const ZSTD_CDict,
         fParams: ZSTD_frameParameters,
@@ -1119,7 +1125,7 @@ extern "C" {
     #[doc = " ZSTD_CCtx_loadDictionary_byReference() :\n  Same as ZSTD_CCtx_loadDictionary(), but dictionary content is referenced, instead of being copied into CCtx.\n  It saves some memory, but also requires that `dict` outlives its usage within `cctx`"]
     pub fn ZSTD_CCtx_loadDictionary_byReference(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -1127,7 +1133,7 @@ extern "C" {
     #[doc = " ZSTD_CCtx_loadDictionary_advanced() :\n  Same as ZSTD_CCtx_loadDictionary(), but gives finer control over\n  how to load the dictionary (by copy ? by reference ?)\n  and how to interpret it (automatic ? force raw mode ? full mode only ?)"]
     pub fn ZSTD_CCtx_loadDictionary_advanced(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -1137,7 +1143,7 @@ extern "C" {
     #[doc = " ZSTD_CCtx_refPrefix_advanced() :\n  Same as ZSTD_CCtx_refPrefix(), but gives finer control over\n  how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?)"]
     pub fn ZSTD_CCtx_refPrefix_advanced(
         cctx: *mut ZSTD_CCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
         dictContentType: ZSTD_dictContentType_e,
     ) -> usize;
@@ -1147,7 +1153,7 @@ extern "C" {
     pub fn ZSTD_CCtx_getParameter(
         cctx: *const ZSTD_CCtx,
         param: ZSTD_cParameter,
-        value: *mut libc::c_int,
+        value: *mut core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1165,7 +1171,7 @@ extern "C" {
     #[doc = " ZSTD_CCtxParams_init() :\n  Initializes the compression parameters of cctxParams according to\n  compression level. All other parameters are reset to their default values."]
     pub fn ZSTD_CCtxParams_init(
         cctxParams: *mut ZSTD_CCtx_params,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1180,7 +1186,7 @@ extern "C" {
     pub fn ZSTD_CCtxParams_setParameter(
         params: *mut ZSTD_CCtx_params,
         param: ZSTD_cParameter,
-        value: libc::c_int,
+        value: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1188,7 +1194,7 @@ extern "C" {
     pub fn ZSTD_CCtxParams_getParameter(
         params: *const ZSTD_CCtx_params,
         param: ZSTD_cParameter,
-        value: *mut libc::c_int,
+        value: *mut core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1202,10 +1208,10 @@ extern "C" {
     #[doc = " ZSTD_compressStream2_simpleArgs() :\n  Same as ZSTD_compressStream2(),\n  but using only integral types as arguments.\n  This variant might be helpful for binders from dynamic languages\n  which have troubles handling structures containing memory pointers."]
     pub fn ZSTD_compressStream2_simpleArgs(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
         dstPos: *mut usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         srcPos: *mut usize,
         endOp: ZSTD_EndDirective,
@@ -1214,14 +1220,14 @@ extern "C" {
 extern "C" {
     #[doc = " ZSTD_isFrame() :\n  Tells if the content of `buffer` starts with a valid Frame Identifier.\n  Note : Frame Identifier is 4 bytes. If `size < 4`, @return will always be 0.\n  Note 2 : Legacy Frame Identifiers are considered valid only if Legacy Support is enabled.\n  Note 3 : Skippable Frame Identifiers are considered valid."]
     pub fn ZSTD_isFrame(
-        buffer: *const libc::c_void,
+        buffer: *const core::ffi::c_void,
         size: usize,
-    ) -> libc::c_uint;
+    ) -> core::ffi::c_uint;
 }
 extern "C" {
     #[doc = " ZSTD_createDDict_byReference() :\n  Create a digested dictionary, ready to start decompression operation without startup delay.\n  Dictionary content is referenced, and therefore stays in dictBuffer.\n  It is important that dictBuffer outlives DDict,\n  it must remain read accessible throughout the lifetime of DDict"]
     pub fn ZSTD_createDDict_byReference(
-        dictBuffer: *const libc::c_void,
+        dictBuffer: *const core::ffi::c_void,
         dictSize: usize,
     ) -> *mut ZSTD_DDict;
 }
@@ -1229,7 +1235,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_loadDictionary_byReference() :\n  Same as ZSTD_DCtx_loadDictionary(),\n  but references `dict` content instead of copying it into `dctx`.\n  This saves memory if `dict` remains around.,\n  However, it's imperative that `dict` remains accessible (and unmodified) while being used, so it must outlive decompression."]
     pub fn ZSTD_DCtx_loadDictionary_byReference(
         dctx: *mut ZSTD_DCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -1237,7 +1243,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_loadDictionary_advanced() :\n  Same as ZSTD_DCtx_loadDictionary(),\n  but gives direct control over\n  how to load the dictionary (by copy ? by reference ?)\n  and how to interpret it (automatic ? force raw mode ? full mode only ?)."]
     pub fn ZSTD_DCtx_loadDictionary_advanced(
         dctx: *mut ZSTD_DCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         dictLoadMethod: ZSTD_dictLoadMethod_e,
         dictContentType: ZSTD_dictContentType_e,
@@ -1247,7 +1253,7 @@ extern "C" {
     #[doc = " ZSTD_DCtx_refPrefix_advanced() :\n  Same as ZSTD_DCtx_refPrefix(), but gives finer control over\n  how to interpret prefix content (automatic ? force raw mode (default) ? full mode only ?)"]
     pub fn ZSTD_DCtx_refPrefix_advanced(
         dctx: *mut ZSTD_DCtx,
-        prefix: *const libc::c_void,
+        prefix: *const core::ffi::c_void,
         prefixSize: usize,
         dictContentType: ZSTD_dictContentType_e,
     ) -> usize;
@@ -1264,7 +1270,7 @@ extern "C" {
     pub fn ZSTD_DCtx_getParameter(
         dctx: *mut ZSTD_DCtx,
         param: ZSTD_dParameter,
-        value: *mut libc::c_int,
+        value: *mut core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1278,10 +1284,10 @@ extern "C" {
     #[doc = " ZSTD_decompressStream_simpleArgs() :\n  Same as ZSTD_decompressStream(),\n  but using only integral types as arguments.\n  This can be helpful for binders from dynamic languages\n  which have troubles handling structures containing memory pointers."]
     pub fn ZSTD_decompressStream_simpleArgs(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
         dstPos: *mut usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
         srcPos: *mut usize,
     ) -> usize;
@@ -1290,27 +1296,27 @@ extern "C" {
     #[doc = " ZSTD_initCStream_srcSize() :\n This function is DEPRECATED, and equivalent to:\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_refCDict(zcs, NULL); // clear the dictionary (if any)\n     ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);\n     ZSTD_CCtx_setPledgedSrcSize(zcs, pledgedSrcSize);\n\n pledgedSrcSize must be correct. If it is not known at init time, use\n ZSTD_CONTENTSIZE_UNKNOWN. Note that, for compatibility with older programs,\n \"0\" also disables frame content size field. It may be enabled in the future.\n This prototype will generate compilation warnings."]
     pub fn ZSTD_initCStream_srcSize(
         zcs: *mut ZSTD_CStream,
-        compressionLevel: libc::c_int,
-        pledgedSrcSize: libc::c_ulonglong,
+        compressionLevel: core::ffi::c_int,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_initCStream_usingDict() :\n This function is DEPRECATED, and is equivalent to:\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_setParameter(zcs, ZSTD_c_compressionLevel, compressionLevel);\n     ZSTD_CCtx_loadDictionary(zcs, dict, dictSize);\n\n Creates of an internal CDict (incompatible with static CCtx), except if\n dict == NULL or dictSize < 8, in which case no dict is used.\n Note: dict is loaded with ZSTD_dct_auto (treated as a full zstd dictionary if\n it begins with ZSTD_MAGIC_DICTIONARY, else as raw content) and ZSTD_dlm_byCopy.\n This prototype will generate compilation warnings."]
     pub fn ZSTD_initCStream_usingDict(
         zcs: *mut ZSTD_CStream,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_initCStream_advanced() :\n This function is DEPRECATED, and is equivalent to:\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_setParams(zcs, params);\n     ZSTD_CCtx_setPledgedSrcSize(zcs, pledgedSrcSize);\n     ZSTD_CCtx_loadDictionary(zcs, dict, dictSize);\n\n dict is loaded with ZSTD_dct_auto and ZSTD_dlm_byCopy.\n pledgedSrcSize must be correct.\n If srcSize is not known at init time, use value ZSTD_CONTENTSIZE_UNKNOWN.\n This prototype will generate compilation warnings."]
     pub fn ZSTD_initCStream_advanced(
         zcs: *mut ZSTD_CStream,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         params: ZSTD_parameters,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
@@ -1326,25 +1332,25 @@ extern "C" {
         zcs: *mut ZSTD_CStream,
         cdict: *const ZSTD_CDict,
         fParams: ZSTD_frameParameters,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
     #[doc = " ZSTD_resetCStream() :\n This function is DEPRECATED, and is equivalent to:\n     ZSTD_CCtx_reset(zcs, ZSTD_reset_session_only);\n     ZSTD_CCtx_setPledgedSrcSize(zcs, pledgedSrcSize);\n Note: ZSTD_resetCStream() interprets pledgedSrcSize == 0 as ZSTD_CONTENTSIZE_UNKNOWN, but\n       ZSTD_CCtx_setPledgedSrcSize() does not do the same, so ZSTD_CONTENTSIZE_UNKNOWN must be\n       explicitly specified.\n\n  start a new frame, using same parameters from previous frame.\n  This is typically useful to skip dictionary loading stage, since it will re-use it in-place.\n  Note that zcs must be init at least once before using ZSTD_resetCStream().\n  If pledgedSrcSize is not known at reset time, use macro ZSTD_CONTENTSIZE_UNKNOWN.\n  If pledgedSrcSize > 0, its value must be correct, as it will be written in header, and controlled at the end.\n  For the time being, pledgedSrcSize==0 is interpreted as \"srcSize unknown\" for compatibility with older programs,\n  but it will change to mean \"empty\" in future version, so use macro ZSTD_CONTENTSIZE_UNKNOWN instead.\n @return : 0, or an error code (which can be tested using ZSTD_isError())\n  This prototype will generate compilation warnings."]
     pub fn ZSTD_resetCStream(
         zcs: *mut ZSTD_CStream,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ZSTD_frameProgression {
-    pub ingested: libc::c_ulonglong,
-    pub consumed: libc::c_ulonglong,
-    pub produced: libc::c_ulonglong,
-    pub flushed: libc::c_ulonglong,
-    pub currentJobID: libc::c_uint,
-    pub nbActiveWorkers: libc::c_uint,
+    pub ingested: core::ffi::c_ulonglong,
+    pub consumed: core::ffi::c_ulonglong,
+    pub produced: core::ffi::c_ulonglong,
+    pub flushed: core::ffi::c_ulonglong,
+    pub currentJobID: core::ffi::c_uint,
+    pub nbActiveWorkers: core::ffi::c_uint,
 }
 extern "C" {
     pub fn ZSTD_getFrameProgression(
@@ -1359,7 +1365,7 @@ extern "C" {
     #[doc = " This function is deprecated, and is equivalent to:\n\n     ZSTD_DCtx_reset(zds, ZSTD_reset_session_only);\n     ZSTD_DCtx_loadDictionary(zds, dict, dictSize);\n\n note: no dictionary will be used if dict == NULL or dictSize < 8"]
     pub fn ZSTD_initDStream_usingDict(
         zds: *mut ZSTD_DStream,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -1376,14 +1382,14 @@ extern "C" {
 }
 pub type ZSTD_sequenceProducer_F = ::core::option::Option<
     unsafe extern "C" fn(
-        sequenceProducerState: *mut libc::c_void,
+        sequenceProducerState: *mut core::ffi::c_void,
         outSeqs: *mut ZSTD_Sequence,
         outSeqsCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
         windowSize: usize,
     ) -> usize,
 >;
@@ -1391,7 +1397,7 @@ extern "C" {
     #[doc = " ZSTD_registerSequenceProducer() :\n Instruct zstd to use a block-level external sequence producer function.\n\n The sequenceProducerState must be initialized by the caller, and the caller is\n responsible for managing its lifetime. This parameter is sticky across\n compressions. It will remain set until the user explicitly resets compression\n parameters.\n\n Sequence producer registration is considered to be an \"advanced parameter\",\n part of the \"advanced API\". This means it will only have an effect on compression\n APIs which respect advanced parameters, such as compress2() and compressStream2().\n Older compression APIs such as compressCCtx(), which predate the introduction of\n \"advanced parameters\", will ignore any external sequence producer setting.\n\n The sequence producer can be \"cleared\" by registering a NULL function pointer. This\n removes all limitations described above in the \"LIMITATIONS\" section of the API docs.\n\n The user is strongly encouraged to read the full API documentation (above) before\n calling this function."]
     pub fn ZSTD_registerSequenceProducer(
         cctx: *mut ZSTD_CCtx,
-        sequenceProducerState: *mut libc::c_void,
+        sequenceProducerState: *mut core::ffi::c_void,
         sequenceProducer: ZSTD_sequenceProducer_F,
     );
 }
@@ -1399,15 +1405,15 @@ extern "C" {
     #[doc = "Buffer-less streaming compression (synchronous mode)\n\nA ZSTD_CCtx object is required to track streaming operations.\nUse ZSTD_createCCtx() / ZSTD_freeCCtx() to manage resource.\nZSTD_CCtx object can be re-used multiple times within successive compression operations.\n\nStart by initializing a context.\nUse ZSTD_compressBegin(), or ZSTD_compressBegin_usingDict() for dictionary compression.\n\nThen, consume your input using ZSTD_compressContinue().\nThere are some important considerations to keep in mind when using this advanced function :\n- ZSTD_compressContinue() has no internal buffer. It uses externally provided buffers only.\n- Interface is synchronous : input is consumed entirely and produces 1+ compressed blocks.\n- Caller must ensure there is enough space in `dst` to store compressed data under worst case scenario.\nWorst case evaluation is provided by ZSTD_compressBound().\nZSTD_compressContinue() doesn't guarantee recover after a failed compression.\n- ZSTD_compressContinue() presumes prior input ***is still accessible and unmodified*** (up to maximum distance size, see WindowLog).\nIt remembers all previous contiguous blocks, plus one separated memory segment (which can itself consists of multiple contiguous blocks)\n- ZSTD_compressContinue() detects that prior input has been overwritten when `src` buffer overlaps.\nIn which case, it will \"discard\" the relevant memory section from its history.\n\nFinish a frame with ZSTD_compressEnd(), which will write the last block(s) and optional checksum.\nIt's possible to use srcSize==0, in which case, it will write a final empty block to end the frame.\nWithout last block mark, frames are considered unfinished (hence corrupted) by compliant decoders.\n\n`ZSTD_CCtx` object can be re-used (ZSTD_compressBegin()) to compress again."]
     pub fn ZSTD_compressBegin(
         cctx: *mut ZSTD_CCtx,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_compressBegin_usingDict(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
-        compressionLevel: libc::c_int,
+        compressionLevel: core::ffi::c_int,
     ) -> usize;
 }
 extern "C" {
@@ -1420,34 +1426,34 @@ extern "C" {
     pub fn ZSTD_copyCCtx(
         cctx: *mut ZSTD_CCtx,
         preparedCCtx: *const ZSTD_CCtx,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_compressContinue(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_compressEnd(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_compressBegin_advanced(
         cctx: *mut ZSTD_CCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
         params: ZSTD_parameters,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
@@ -1455,14 +1461,14 @@ extern "C" {
         cctx: *mut ZSTD_CCtx,
         cdict: *const ZSTD_CDict,
         fParams: ZSTD_frameParameters,
-        pledgedSrcSize: libc::c_ulonglong,
+        pledgedSrcSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
     #[doc = "Buffer-less streaming decompression (synchronous mode)\n\nA ZSTD_DCtx object is required to track streaming operations.\nUse ZSTD_createDCtx() / ZSTD_freeDCtx() to manage it.\nA ZSTD_DCtx object can be re-used multiple times.\n\nFirst typical operation is to retrieve frame parameters, using ZSTD_getFrameHeader().\nFrame header is extracted from the beginning of compressed frame, so providing only the frame's beginning is enough.\nData fragment must be large enough to ensure successful decoding.\n`ZSTD_frameHeaderSize_max` bytes is guaranteed to always be large enough.\nresult  : 0 : successful decoding, the `ZSTD_frameHeader` structure is correctly filled.\n>0 : `srcSize` is too small, please provide at least result bytes on next attempt.\nerrorCode, which can be tested using ZSTD_isError().\n\nIt fills a ZSTD_frameHeader structure with important information to correctly decode the frame,\nsuch as the dictionary ID, content size, or maximum back-reference distance (`windowSize`).\nNote that these values could be wrong, either because of data corruption, or because a 3rd party deliberately spoofs false information.\nAs a consequence, check that values remain within valid application range.\nFor example, do not allocate memory blindly, check that `windowSize` is within expectation.\nEach application can set its own limits, depending on local restrictions.\nFor extended interoperability, it is recommended to support `windowSize` of at least 8 MB.\n\nZSTD_decompressContinue() needs previous data blocks during decompression, up to `windowSize` bytes.\nZSTD_decompressContinue() is very sensitive to contiguity,\nif 2 blocks don't follow each other, make sure that either the compressor breaks contiguity at the same place,\nor that previous contiguous segment is large enough to properly handle maximum back-reference distance.\nThere are multiple ways to guarantee this condition.\n\nThe most memory efficient way is to use a round buffer of sufficient size.\nSufficient size is determined by invoking ZSTD_decodingBufferSize_min(),\nwhich can return an error code if required value is too large for current system (in 32-bits mode).\nIn a round buffer methodology, ZSTD_decompressContinue() decompresses each block next to previous one,\nup to the moment there is not enough room left in the buffer to guarantee decoding another full block,\nwhich maximum size is provided in `ZSTD_frameHeader` structure, field `blockSizeMax`.\nAt which point, decoding can resume from the beginning of the buffer.\nNote that already decoded data stored in the buffer should be flushed before being overwritten.\n\nThere are alternatives possible, for example using two or more buffers of size `windowSize` each, though they consume more memory.\n\nFinally, if you control the compression process, you can also ignore all buffer size rules,\nas long as the encoder and decoder progress in \"lock-step\",\naka use exactly the same buffer sizes, break contiguity at the same place, etc.\n\nOnce buffers are setup, start decompression, with ZSTD_decompressBegin().\nIf decompression requires a dictionary, use ZSTD_decompressBegin_usingDict() or ZSTD_decompressBegin_usingDDict().\n\nThen use ZSTD_nextSrcSizeToDecompress() and ZSTD_decompressContinue() alternatively.\nZSTD_nextSrcSizeToDecompress() tells how many bytes to provide as 'srcSize' to ZSTD_decompressContinue().\nZSTD_decompressContinue() requires this _exact_ amount of bytes, or it will fail.\n\nresult of ZSTD_decompressContinue() is the number of bytes regenerated within 'dst' (necessarily <= dstCapacity).\nIt can be zero : it just means ZSTD_decompressContinue() has decoded some metadata item.\nIt can also be an error code, which can be tested with ZSTD_isError().\n\nA frame is fully decoded when ZSTD_nextSrcSizeToDecompress() returns zero.\nContext can then be reset to start a new decompression.\n\nNote : it's possible to know if next input to present is a header or a block, using ZSTD_nextInputType().\nThis information is not required to properly decode a frame.\n\n== Special case : skippable frames ==\n\nSkippable frames allow integration of user-defined data into a flow of concatenated frames.\nSkippable frames will be ignored (skipped) by decompressor.\nThe format of skippable frames is as follows :\na) Skippable frame ID - 4 Bytes, Little endian format, any value from 0x184D2A50 to 0x184D2A5F\nb) Frame Size - 4 Bytes, Little endian format, unsigned 32-bits\nc) Frame Content - any content (User Data) of length equal to Frame Size\nFor skippable frames ZSTD_getFrameHeader() returns zfhPtr->frameType==ZSTD_skippableFrame.\nFor skippable frames ZSTD_decompressContinue() always returns 0 : it only skips the content."]
     pub fn ZSTD_decodingBufferSize_min(
-        windowSize: libc::c_ulonglong,
-        frameContentSize: libc::c_ulonglong,
+        windowSize: core::ffi::c_ulonglong,
+        frameContentSize: core::ffi::c_ulonglong,
     ) -> usize;
 }
 extern "C" {
@@ -1471,7 +1477,7 @@ extern "C" {
 extern "C" {
     pub fn ZSTD_decompressBegin_usingDict(
         dctx: *mut ZSTD_DCtx,
-        dict: *const libc::c_void,
+        dict: *const core::ffi::c_void,
         dictSize: usize,
     ) -> usize;
 }
@@ -1487,9 +1493,9 @@ extern "C" {
 extern "C" {
     pub fn ZSTD_decompressContinue(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
@@ -1516,25 +1522,25 @@ extern "C" {
 extern "C" {
     pub fn ZSTD_compressBlock(
         cctx: *mut ZSTD_CCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_decompressBlock(
         dctx: *mut ZSTD_DCtx,
-        dst: *mut libc::c_void,
+        dst: *mut core::ffi::c_void,
         dstCapacity: usize,
-        src: *const libc::c_void,
+        src: *const core::ffi::c_void,
         srcSize: usize,
     ) -> usize;
 }
 extern "C" {
     pub fn ZSTD_insertBlock(
         dctx: *mut ZSTD_DCtx,
-        blockStart: *const libc::c_void,
+        blockStart: *const core::ffi::c_void,
         blockSize: usize,
     ) -> usize;
 }


### PR DESCRIPTION
I do not know if there is any technical reason why this would be a bad idea, but I propose swapping all uses of libc in `zstd-safe` and `zstd-sys` with `core::ffi` in order to support targets which do not fully support libc, such as `aarch64-nintendo-switch-freestanding`.