### PR TITLE
Fix minimum supported rust version to 1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.13.0"
 exclude = ["assets/*.zst", "/.github"]
 readme = "Readme.md"
 edition = "2018"
-rust-version = "1.66.1"
+rust-version = "1.66"
 
 [package.metadata.docs.rs]
 features = ["experimental", "zstdmt", "zdict_builder", "doc-cfg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.13.0"
 exclude = ["assets/*.zst", "/.github"]
 readme = "Readme.md"
 edition = "2018"
-rust-version = "1.64"
+rust-version = "1.66.1"
 
 [package.metadata.docs.rs]
 features = ["experimental", "zstdmt", "zdict_builder", "doc-cfg"]

--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/gyscos/zstd-rs"
 license = "MIT/Apache-2.0"
 readme = "Readme.md"
 edition = "2018"
-rust-version = "1.64"
+rust-version = "1.66.1"
 exclude = ["update_consts.sh"]
 
 [package.metadata.docs.rs]

--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/gyscos/zstd-rs"
 license = "MIT/Apache-2.0"
 readme = "Readme.md"
 edition = "2018"
-rust-version = "1.66.1"
+rust-version = "1.66"
 exclude = ["update_consts.sh"]
 
 [package.metadata.docs.rs]

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -18,7 +18,7 @@ readme = "Readme.md"
 repository = "https://github.com/gyscos/zstd-rs"
 version = "2.0.9+zstd.1.5.5"
 edition = "2018"
-rust-version = "1.64"
+rust-version = "1.66.1"
 
 # Use include instead of exclude, as a (temporary)
 # workaround for https://github.com/rust-lang/cargo/issues/9555

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -18,7 +18,7 @@ readme = "Readme.md"
 repository = "https://github.com/gyscos/zstd-rs"
 version = "2.0.9+zstd.1.5.5"
 edition = "2018"
-rust-version = "1.66.1"
+rust-version = "1.66"
 
 # Use include instead of exclude, as a (temporary)
 # workaround for https://github.com/rust-lang/cargo/issues/9555


### PR DESCRIPTION
Matching PR for issue https://github.com/gyscos/zstd-rs/issues/253 bumping the minimum supported rust version to 1.66 in Cargo.toml.