### PR TITLE
Bump zstd-sys version in zstd-safe

### DIFF
--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["update_consts.sh"]
 features = ["experimental", "arrays", "std", "zdict_builder", "doc-cfg"]
 
 [dependencies]
-zstd-sys = { path = "zstd-sys", version = "2.0.7", default-features = false }
+zstd-sys = { path = "zstd-sys", version = "2.0.9", default-features = false }
 
 [features]
 default = ["legacy", "arrays", "zdict_builder"]


### PR DESCRIPTION
Hi, we are building a library targeting wasm32-unknown-emscripten that uses zstd, and noticed that recent zstd-sys updates regarding emscripten (https://github.com/gyscos/zstd-rs/pull/209, https://github.com/gyscos/zstd-rs/commit/92f87dca4987555fe8a87504dea68b37a29d62b9) are not applied to zstd-safe 7.0.0. It would be great to have a new release that includes these updates.