### PR TITLE
Make ref_prefix available

### DIFF
--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -167,6 +167,20 @@ impl<'a> Decoder<'a> {
         Ok(Decoder { context })
     }
 
+    /// Creates a new decoder, using a ref prefix
+    pub fn with_ref_prefix<'b>(
+        ref_prefix: &'b [u8],
+    ) -> io::Result<Self>
+    where
+        'b: 'a,
+    {
+        let mut context = zstd_safe::DCtx::create();
+        context
+            .ref_prefix(ref_prefix)
+            .map_err(map_error_code)?;
+        Ok(Decoder { context })
+    }
+
     /// Sets a decompression parameter for this decoder.
     pub fn set_parameter(&mut self, parameter: DParameter) -> io::Result<()> {
         self.context
@@ -266,6 +280,27 @@ impl<'a> Encoder<'a> {
         context
             .ref_cdict(dictionary.as_cdict())
             .map_err(map_error_code)?;
+        Ok(Encoder { context })
+    }
+
+    /// Creates a new encoder initialized with the given ref prefix.
+    pub fn with_ref_prefix<'b>(
+        level: i32,
+        ref_prefix: &'b [u8]
+    ) -> io::Result<Self>
+    where
+        'b: 'a,
+    {
+        let mut context = zstd_safe::CCtx::create();
+
+        context
+            .set_parameter(CParameter::CompressionLevel(level))
+            .map_err(map_error_code)?;
+
+        context
+            .ref_prefix(ref_prefix)
+            .map_err(map_error_code)?;
+
         Ok(Encoder { context })
     }
 

--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -71,6 +71,22 @@ impl<'a, R: BufRead> Decoder<'a, R> {
         Ok(Decoder { reader })
     }
 
+    /// Creates a new decoder, using a ref prefix.
+    ///
+    /// The prefix must be the same as the one used during compression.
+    pub fn with_ref_prefix<'b>(
+        reader: R,
+        ref_prefix: &'b [u8]
+    ) -> io::Result<Self>
+    where
+        'b: 'a,
+    {
+        let decoder = raw::Decoder::with_ref_prefix(ref_prefix)?;
+        let reader = zio::Reader::new(reader, decoder);
+
+        Ok(Decoder { reader })
+    }
+
     /// Recommendation for the size of the output buffer.
     pub fn recommended_output_size() -> usize {
         zstd_safe::DCtx::out_size()

--- a/src/stream/write/mod.rs
+++ b/src/stream/write/mod.rs
@@ -209,6 +209,20 @@ impl<'a, W: Write> Encoder<'a, W> {
         Ok(Encoder { writer })
     }
 
+    /// Creates a new encoder, using a ref prefix
+    pub fn with_ref_prefix<'b>(
+        writer: W,
+        level: i32,
+        ref_prefix: &'b [u8],
+    ) -> io::Result<Self>
+    where
+        'b: 'a,
+    {
+        let encoder = raw::Encoder::with_ref_prefix(level, ref_prefix)?;
+        let writer = zio::Writer::new(writer, encoder);
+        Ok(Encoder { writer })
+    }
+
     /// Returns a wrapper around `self` that will finish the stream on drop.
     pub fn auto_finish(self) -> AutoFinishEncoder<'a, W> {
         AutoFinishEncoder {


### PR DESCRIPTION
ref_prefix is already available in DCtx and CCtx but not Encoder and Decoder.

ref_prefix is important when trying to implement --patch-from as explained in https://github.com/facebook/zstd/issues/2835