### PR TITLE
Fix wasm32-unknown-unknown support

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -22,6 +22,6 @@ jobs:
         submodules: recursive
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --target wasm32-unknown-unknown
     - name: Build with feature thin
-      run: cargo build --verbose --features thin
+      run: cargo build --verbose --features thin --target wasm32-unknown-unknown

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -143,7 +143,6 @@ fn compile_zstd() {
         cargo_print(&"rerun-if-changed=wasm-shim/string.h");
 
         config.include("wasm-shim/");
-        config.define("XXH_STATIC_ASSERT", Some("0"));
     }
 
     // Some extra parameters


### PR DESCRIPTION
`XXH_STATIC_ASSERT` appears to already have a reasonable definition, and defining it to `0` breaks uses of it.

I'm not sure why that definition was added originally.

This also fixes the github action workflow to actually build the wasm target; previously it was just building the native target which allowed this issue to slip through.

Fixes #271.