### PR TITLE
remove hardcoded BufRead trait bounds

### DIFF
--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -12,12 +12,12 @@ mod tests;
 ///
 /// This allows to read a stream of compressed data
 /// (good for files or heavy network stream).
-pub struct Decoder<'a, R: BufRead> {
+pub struct Decoder<'a, R> {
     reader: zio::Reader<R, raw::Decoder<'a>>,
 }
 
 /// An encoder that compress input data from another `Read`.
-pub struct Encoder<'a, R: BufRead> {
+pub struct Encoder<'a, R> {
     reader: zio::Reader<R, raw::Encoder<'a>>,
 }
 


### PR DESCRIPTION
# Problem

Rust structs with generic type parameters are typically not declared with trait bounds on the struct itself, as this makes it difficult to compose into other generic structs. The `zip` crate depends on `zstd`, and is unable to declare a generic `ZipFileReader` enum (e.g. https://github.com/zip-rs/zip2/blob/b6e0a0693ba2d07f541cd9017b60df7e65817e48/src/read.rs#L190) without creating a vtable `&'a mut dyn Read`, since the `R: BufRead` bound on the `Decoder` struct declaration requires a concrete type implementing `BufRead`, whereas `io::BufReader` doesn't have the same `R: Read` bound on the struct declaration.

In essence, we currently have this:
```rust
pub(crate) enum ZipFileReader<'a> {
    NoReader,
    Raw(io::Take<&'a mut dyn Read>),
    Stored(Crc32Reader<&'a mut dyn Read>),
    #[cfg(feature = "_deflate-any")]
    Deflated(Crc32Reader<DeflateDecoder<&'a mut dyn Read>>),
    #[cfg(feature = "deflate64")]
    Deflate64(Crc32Reader<Deflate64Decoder<io::BufReader<&'a mut dyn Read>>>),
    #[cfg(feature = "bzip2")]
    Bzip2(Crc32Reader<BzDecoder<&'a mut dyn Read>>),
    #[cfg(feature = "zstd")]
    Zstd(Crc32Reader<ZstdDecoder<'a, io::BufReader<&'a mut dyn Read>>>),
    #[cfg(feature = "lzma")]
    Lzma(Crc32Reader<Box<LzmaDecoder<&'a mut dyn Read>>>),
}
```

but we would like to be able to have this instead:
```rust
pub(crate) enum EntryReader<R> {
    NoReader,
    Raw(R),
    Stored(Crc32Reader<R>),
    #[cfg(feature = "_deflate-any")]
    Deflated(Crc32Reader<DeflateDecoder<R>>),
    #[cfg(feature = "deflate64")]
    Deflate64(Crc32Reader<Deflate64Decoder<io::BufReader<R>>>),
    #[cfg(feature = "bzip2")]
    Bzip2(Crc32Reader<BzDecoder<R>>),
    #[cfg(feature = "zstd")]
    Zstd(Crc32Reader<ZstdDecoder<'static, io::BufReader<R>>>),
    #[cfg(feature = "lzma")]
    Lzma(Crc32Reader<Box<LzmaDecoder<R>>>),
}
```

This avoids the creation of a vtable indirection and unnecessary lifetime bound.

# Solution
Remove the `R: BufRead` bounds on the `Encoder` and `Decoder` struct declarations.

# Result
This is not a breaking change.