### PR TITLE
Update `need_wasm_shim` logic for `wasm32-wasip1`

### DIFF
--- a/src/stream/functions.rs
+++ b/src/stream/functions.rs
@@ -55,5 +55,5 @@ where
     Ok(())
 }
 
-#[cfg(tests)]
+#[cfg(test)]
 mod tests {}

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -135,7 +135,7 @@ fn compile_zstd() {
     // See: https://github.com/gyscos/zstd-rs/pull/209
     let need_wasm_shim = !cfg!(feature = "no_wasm_shim")
         && env::var("TARGET").map_or(false, |target| {
-            target == "wasm32-unknown-unknown" || target == "wasm32-wasi"
+            target == "wasm32-unknown-unknown" || target.starts_with("wasm32-wasi")
         });
 
     if need_wasm_shim {


### PR DESCRIPTION
Hi,

the `wasm32-wasi` target is being renamed to `wasm32-wasip1` and the
`wasm32-wasi` target will be removed in the future. It looks like the
shim will also be useful (required?) for `wasm32-wasip2`, so I've included all future `wasm32-wasi*` targets for now.

Thanks!