### PR TITLE
release: zstd 0.13.3, zstd-safe 7.3.0, zstd-sys 2.0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["compression", "api-bindings"]
 license = "MIT"
 name = "zstd"
 repository = "https://github.com/gyscos/zstd-rs"
-version = "0.13.2"
+version = "0.13.3"
 exclude = ["assets/*.zst", "/.github"]
 readme = "Readme.md"
 edition = "2018"
@@ -23,7 +23,7 @@ travis-ci = { repository = "gyscos/zstd-rs" }
 zstd-safe = { path = "zstd-safe", version = "7.1.0", default-features = false, features = ["std"] }
 
 [dev-dependencies]
-clap = {version = "4.0", features=["derive"]}
+clap = { version = "4.0", features=["derive"] }
 humansize = "2.0"
 partial-io = "0.5"
 walkdir = "2.2"

--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Alexandre Bury <alexandre.bury@gmail.com>"]
 name = "zstd-safe"
 build = "build.rs"
-version = "7.2.0"
+version = "7.3.0"
 description = "Safe low-level bindings for the zstd compression library."
 keywords = ["zstd", "zstandard", "compression"]
 categories = ["api-bindings", "compression"]
@@ -17,7 +17,7 @@ exclude = ["update_consts.sh"]
 features = ["experimental", "arrays", "std", "zdict_builder", "doc-cfg"]
 
 [dependencies]
-zstd-sys = { path = "zstd-sys", version = "2.0.10", default-features = false }
+zstd-sys = { path = "zstd-sys", version = "2.0.13", default-features = false }
 
 [features]
 default = ["legacy", "arrays", "zdict_builder"]

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -16,7 +16,7 @@ links = "zstd"
 name = "zstd-sys"
 readme = "Readme.md"
 repository = "https://github.com/gyscos/zstd-rs"
-version = "2.0.12+zstd.1.5.6"
+version = "2.0.13+zstd.1.5.6"
 edition = "2018"
 rust-version = "1.64"
 


### PR DESCRIPTION
Includes the fix for compilation on new Wasm targets https://github.com/gyscos/zstd-rs/commit/fc3a73100b6d3f2ff6dd3da0ff14dd9185ba02f0