### PR TITLE
Don't allow writing to finished Encoder

### DIFF
--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -89,7 +89,7 @@ impl<'a, R: BufRead> Decoder<'a, R> {
     /// The prefix must be the same as the one used during compression.
     pub fn with_ref_prefix<'b>(
         reader: R,
-        ref_prefix: &'b [u8]
+        ref_prefix: &'b [u8],
     ) -> io::Result<Self>
     where
         'b: 'a,

--- a/src/stream/tests.rs
+++ b/src/stream/tests.rs
@@ -267,3 +267,12 @@ fn reader_to_writer() {
 
     assert_eq!(clear, &decompressed_buffer[..]);
 }
+
+#[test]
+fn test_finish_empty_encoder() {
+    use std::io::Write;
+    let mut enc = Encoder::new(Vec::new(), 0).unwrap();
+    enc.do_finish().unwrap();
+    enc.write_all(b"this should not work").unwrap_err();
+    enc.finish().unwrap();
+}

--- a/src/stream/zio/writer.rs
+++ b/src/stream/zio/writer.rs
@@ -174,6 +174,12 @@ where
     D: Operation,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.finished {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "encoder is finished",
+            ));
+        }
         // Keep trying until _something_ has been consumed.
         // As soon as some input has been taken, we cannot afford
         // to take any chance: if an error occurs, the user couldn't know


### PR DESCRIPTION
If an Encoder is finished, it will swallow writes without error but never let you flush or finish those.