### PR TITLE
Require a more recent version of pkg-config

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -56,7 +56,7 @@ default-features = false
 features = ["runtime", "which-rustfmt"]
 
 [build-dependencies.pkg-config]
-version = "0.3"
+version = "0.3.28"
 
 [build-dependencies.cc]
 version = "1.0.45"


### PR DESCRIPTION
Cargo.toml says that zstd requires pkg-config "0.3".

This version specification is typically resolved to the most recent pkg-config, but technically, it could be resolved to "0.3.0". However, this version of pkg-config is almost 10 years old, and does not actually work with zstd.

Some projects use a CI-step that checks that selecting minimum versions of all dependencies actually works, and such CI now fails if zstd is in the project crate graph, because of this issue.

We should require a more recent version of pkg-config. I arbitrarily selected "0.3.28", but of course the most recent one will actually be selected for most users. This PR just steps the pkg-config version to 0.3.28. The earliest version that actually compiles is "0.3.7", but it seems strange to explicitly name such an old version.


