### PR TITLE
Add Send and Sync markers for AdvancedSeekable

### DIFF
--- a/zstd-safe/src/seekable.rs
+++ b/zstd-safe/src/seekable.rs
@@ -455,6 +455,9 @@ pub struct AdvancedSeekable<'a, F> {
     src: *mut F,
 }
 
+unsafe impl<F> Send for AdvancedSeekable<'_, F> where F: Send {}
+unsafe impl<F> Sync for AdvancedSeekable<'_, F> where F: Sync {}
+
 #[cfg(feature = "std")]
 impl<'a, F> core::ops::Deref for AdvancedSeekable<'a, F> {
     type Target = Seekable<'a>;


### PR DESCRIPTION
Right now `AdvancedSeekable` isn't thread-safe as it contains a raw pointer to `F`. This adds impls to make `AdvancedSeekable` `Send` or `Sync`, if `F` is `Send` or `Sync`.