### PR TITLE
Add cfg attribute for advanced seekable impls and make seek table creation safe

### DIFF
--- a/zstd-safe/src/seekable.rs
+++ b/zstd-safe/src/seekable.rs
@@ -599,17 +599,11 @@ unsafe impl Send for SeekTable {}
 unsafe impl Sync for SeekTable {}
 
 impl SeekTable {
-    // `ZSTD_seekTable_create_fromSeekable` causes a segmentation fault when called with an
-    // uninitialized Seekable. This function is safe once the issue is resolved and released
-    // upstream.
-    // See https://github.com/facebook/zstd/issues/4200 and https://github.com/facebook/zstd/pull/4201
     /// Try to create a `SeekTable` from a `Seekable`.
     ///
     /// Memory constrained use cases that manage multiple archives benefit from retaining
     /// multiple archive seek tables without retaining a `Seekable` instance for each.
-    ///
-    /// May cause a segmentation fault when called wih an uninitialized `Seekable`.
-    pub unsafe fn try_from_seekable<'a>(
+    pub fn try_from_seekable<'a>(
         value: &Seekable<'a>,
     ) -> Result<Self, SeekTableCreateError> {
         // Safety: Just FFI

--- a/zstd-safe/src/seekable.rs
+++ b/zstd-safe/src/seekable.rs
@@ -455,7 +455,9 @@ pub struct AdvancedSeekable<'a, F> {
     src: *mut F,
 }
 
+#[cfg(feature = "std")]
 unsafe impl<F> Send for AdvancedSeekable<'_, F> where F: Send {}
+#[cfg(feature = "std")]
 unsafe impl<F> Sync for AdvancedSeekable<'_, F> where F: Sync {}
 
 #[cfg(feature = "std")]

--- a/zstd-safe/src/tests.rs
+++ b/zstd-safe/src/tests.rs
@@ -209,6 +209,11 @@ fn test_seekable_seek_table() {
 
     let seekable_archive = new_seekable_archive(INPUT);
     let mut seekable = Seekable::create();
+
+    // Assert that creating a SeekTable from an uninitialized seekable errors.
+    // This led to segfaults with zstd versions prior v1.5.7
+    assert!(SeekTable::try_from_seekable(&seekable).is_err());
+
     seekable
         .init_buff(&seekable_archive)
         .map_err(zstd_safe::get_error_name)
@@ -216,7 +221,7 @@ fn test_seekable_seek_table() {
 
     // Try to create a seek table from the seekable
     let seek_table =
-        unsafe { SeekTable::try_from_seekable(&seekable).unwrap() };
+        { SeekTable::try_from_seekable(&seekable).unwrap() };
 
     // Seekable and seek table should return the same results
     assert_eq!(seekable.num_frames(), seek_table.num_frames());


### PR DESCRIPTION
Two minor fixes

- The impls on `AdvancedSeekable` had no `cfg` macros, leading to a compilation failure when the `seekable` feature was enabled but not `std`, e.g.:

```text
cargo t -F seekable
   Compiling zstd-safe v7.2.3 (/home/rob/misc/zstd-rs/zstd-safe)
   Compiling zstd-sys v2.0.14+zstd.1.5.7 (/home/rob/misc/zstd-rs/zstd-safe/zstd-sys)
error[E0412]: cannot find type `AdvancedSeekable` in this scope
   --> src/seekable.rs:458:25
    |
458 | unsafe impl<F> Send for AdvancedSeekable<'_, F> where F: Send {}
    |                         ^^^^^^^^^^^^^^^^ not found in this scope

error[E0412]: cannot find type `AdvancedSeekable` in this scope
   --> src/seekable.rs:459:25
    |
459 | unsafe impl<F> Sync for AdvancedSeekable<'_, F> where F: Sync {}
    |                         ^^^^^^^^^^^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0412`.
error: could not compile `zstd-safe` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `zstd-safe` (lib test) due to 2 previous errors
```

- With zstd v1.5.7 a segfault that previously could occur in `SeekTable::try_from_seekable` is fixed, hence the function can be made safe now