### PR TITLE
Add zstd-safe to CI tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,3 +27,12 @@ jobs:
       run: cargo build --verbose --features thin
     - name: Run tests
       run: cargo test --verbose --features thin
+
+    - name: Build zstd-safe with feature seekable
+      run: cargo build --manifest-path zstd-safe/Cargo.toml --verbose --features seekable
+    - name: Run zstd-safe tests with feature seekable
+      run: cargo test --manifest-path zstd-safe/Cargo.toml --verbose --features seekable
+    - name: Build zstd-safe with features std and seekable
+      run: cargo build --manifest-path zstd-safe/Cargo.toml --verbose --features std,seekable
+    - name: Run zstd-safe tests with features std and seekable
+      run: cargo test --manifest-path zstd-safe/Cargo.toml --verbose --features std,seekable


### PR DESCRIPTION
Follow-up to #328 

Build and test zstd-safe with different feature combinations in CI.
I only added it to Linux for now since I'm not sure about the others. Let me know if this was meant to be different.