### PR TITLE
Add seekable format sources to zstd-sys package

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -34,6 +34,8 @@ include = [
     "/zstd/lib/**/*.c",
     "/zstd/lib/**/*.h",
     "/zstd/lib/**/*.S",
+    "/zstd/contrib/seekable_format/*.c",
+    "/zstd/contrib/seekable_format/*.h",
 ]
 # exclude = [
 #     "zstd",


### PR DESCRIPTION
I just noticed that `zstd-sys` won't compile due to missing files, if `zstd-safe v7.2.3` is used as dependency and the `seekable` feature is enabled.

This is what I use in my projects `Cargo.toml`

```toml
zstd-safe = { version = "7.2.3", features = ["std", "seekable"] }
```

And this is the error I get 

```
error: failed to run custom build command for `zstd-sys v2.0.14+zstd.1.5.7`

Caused by:
  process didn't exit successfully: `/home/rob/misc/zeekstd/target/debug/build/zstd-sys-2b9004de1680cb78/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=ZSTD_SYS_USE_PKG_CONFIG

  --- stderr
  thread 'main' panicked at /home/rob/.cargo/registry/src/index.crates.io-6f17d22bba15001f/zstd-sys-2.0.14+zstd.1.5.7/build.rs:113:14:
  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Including the seekable formats source files should fix the problem. 