### PR TITLE
Release zstd-sys and zstd-safe

### DIFF
--- a/zstd-safe/Cargo.toml
+++ b/zstd-safe/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Alexandre Bury <alexandre.bury@gmail.com>"]
 name = "zstd-safe"
 build = "build.rs"
-version = "7.2.3"
+version = "7.2.4"
 description = "Safe low-level bindings for the zstd compression library."
 keywords = ["zstd", "zstandard", "compression"]
 categories = ["api-bindings", "compression"]
@@ -17,7 +17,7 @@ exclude = ["update_consts.sh"]
 features = ["experimental", "arrays", "std", "zdict_builder", "doc-cfg"]
 
 [dependencies]
-zstd-sys = { path = "zstd-sys", version = "2.0.14", default-features = false }
+zstd-sys = { path = "zstd-sys", version = "2.0.15", default-features = false }
 
 [features]
 default = ["legacy", "arrays", "zdict_builder"]

--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -16,7 +16,7 @@ links = "zstd"
 name = "zstd-sys"
 readme = "Readme.md"
 repository = "https://github.com/gyscos/zstd-rs"
-version = "2.0.14+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 edition = "2018"
 rust-version = "1.64"
 


### PR DESCRIPTION
Would you mind to release new versions of `zstd-sys` and `zstd-safe`? I would like to use zstd-safe with the seekable feature but this is currently not possible with version `7.2.3` form crates.io (due to https://github.com/gyscos/zstd-rs/pull/330).