### PR TITLE
enhancement: expose `ZSTD_getFrameProgression` through `CCtx`

### DIFF
--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -842,6 +842,16 @@ impl<'a> CCtx<'a> {
             )
         })
     }
+
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(
+        feature = "doc-cfg",
+        doc(cfg(feature = "experimental"))
+    )]
+    pub fn get_frame_progression(&self) -> zstd_sys::ZSTD_frameProgression {
+        // Safety: Just FFI
+        unsafe { zstd_sys::ZSTD_getFrameProgression(self.0.as_ptr()) }
+    }
 }
 
 impl<'a> Drop for CCtx<'a> {

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -36,6 +36,11 @@ pub use zstd_sys;
 /// How to compress data.
 pub use zstd_sys::ZSTD_strategy as Strategy;
 
+/// Frame progression state.
+#[cfg(feature = "experimental")]
+#[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "experimental")))]
+pub use zstd_sys::ZSTD_frameProgression as FrameProgression;
+
 /// Reset directive.
 // pub use zstd_sys::ZSTD_ResetDirective as ResetDirective;
 use core::ffi::{c_char, c_int, c_ulonglong, c_void};
@@ -844,11 +849,8 @@ impl<'a> CCtx<'a> {
     }
 
     #[cfg(feature = "experimental")]
-    #[cfg_attr(
-        feature = "doc-cfg",
-        doc(cfg(feature = "experimental"))
-    )]
-    pub fn get_frame_progression(&self) -> zstd_sys::ZSTD_frameProgression {
+    #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "experimental")))]
+    pub fn get_frame_progression(&self) -> FrameProgression {
         // Safety: Just FFI
         unsafe { zstd_sys::ZSTD_getFrameProgression(self.0.as_ptr()) }
     }


### PR DESCRIPTION
This PR exposes the ability to query the frame progression state (`ZSTD_getFrameProgression`) through `CCtx`.

I opted to simply return `ZSTD_frameProgression` directly rather than creating a newtype or anything.