### PR TITLE
Add missing `with_context` constructors

### DIFF
--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -166,6 +166,19 @@ impl<R: BufRead> Encoder<'static, R> {
 }
 
 impl<'a, R: BufRead> Encoder<'a, R> {
+    /// Creates a new encoder which employs the provided context for serialization.
+    pub fn with_context(
+        reader: R,
+        context: &'a mut zstd_safe::CCtx<'static>,
+    ) -> Self {
+        Self {
+            reader: zio::Reader::new(
+                reader,
+                raw::Encoder::with_context(context),
+            ),
+        }
+    }
+
     /// Creates a new encoder, using an existing `EncoderDictionary`.
     ///
     /// The dictionary must be the same as the one used during compression.

--- a/src/stream/write/mod.rs
+++ b/src/stream/write/mod.rs
@@ -370,6 +370,15 @@ impl<'a, W: Write> Decoder<'a, W> {
         Decoder { writer }
     }
 
+    /// Creates a decoder that uses the provided context to decompress a stream.
+    pub fn with_context(
+        writer: W,
+        context: &'a mut zstd_safe::DCtx<'static>,
+    ) -> Self {
+        let encoder = raw::Decoder::with_context(context);
+        Self::with_decoder(writer, encoder)
+    }
+
     /// Creates a new decoder, using an existing prepared `DecoderDictionary`.
     ///
     /// (Provides better compression ratio for small files,


### PR DESCRIPTION
It seems like it was intended for these to be added in #247. I've been using this implementation and it seems to work fine.