### PR TITLE
Fix typo: "contraint" → "constraint" in documentation

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -151,7 +151,7 @@ macro_rules! encoder_parameters {
         /// (~0.1%), but may decrease end-to-end latency in low-bandwidth environments (time to
         /// first decompressed byte).
         ///
-        /// No value, or a value of zero, results in no contraint for the block sizes.
+        /// No value, or a value of zero, results in no constraint for the block sizes.
         pub fn set_target_cblock_size(
             &mut self,
             target_size: Option<u32>,


### PR DESCRIPTION


**Description:**  
This pull request corrects a minor typo in the documentation comment for the set_target_cblock_size function, changing "contraint" to "constraint" for improved clarity and accuracy. 