### PR TITLE
Only set -fvisibility=hidden if not using MSVC

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -210,7 +210,9 @@ fn compile_zstd() {
     // Hide symbols from resulting library,
     // so we can be used with another zstd-linking lib.
     // See https://github.com/gyscos/zstd-rs/issues/58
-    config.flag("-fvisibility=hidden");
+    if ! cfg!(target_env = "msvc") {
+        config.flag("-fvisibility=hidden");
+    }
     config.define("XXH_PRIVATE_API", Some(""));
     config.define("ZSTDLIB_VISIBILITY", Some(""));
     #[cfg(feature = "zdict_builder")]


### PR DESCRIPTION
Fixing #352 when using `x86_64-pc-windows-msvc`:

```
warning: zstd-sys@2.0.16+zstd.1.5.7: cl : Command line warning D9002 : ignoring unknown option '-fvisibility=hidden'
```