### PR TITLE
Add RISC-V RVV optimization support for zstd C library compilation

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -178,7 +178,10 @@ fn compile_zstd() {
             &mut config,
             &["-march=rv64gcv", "-march=rv64gc"],
         );
-        config.flag_if_supported("-O3");
+        let profile = env::var("PROFILE").unwrap_or_default();
+        if profile == "release" {
+            config.flag_if_supported("-O3");
+        }
     }
 
     if cfg!(feature = "fat-lto") {

--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -172,6 +172,14 @@ fn compile_zstd() {
         .flag_if_supported("-ffunction-sections")
         .flag_if_supported("-fdata-sections")
         .flag_if_supported("-fmerge-all-constants");
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    if target_arch == "riscv64" {
+        flag_if_supported_with_fallbacks(
+            &mut config,
+            &["-march=rv64gcv", "-march=rv64gc"],
+        );
+        config.flag_if_supported("-O3");
+    }
 
     if cfg!(feature = "fat-lto") {
         config.flag_if_supported("-flto");


### PR DESCRIPTION
This commit adds automatic RISC-V RVV (RISC-V Vector Extension) optimization support when building the zstd C library on RISC-V 64-bit platforms.

Changes:

- Detect riscv64 target architecture in build.rs

- Automatically apply -march=rv64gcv flag (with fallback to -march=rv64gc)

- Add -O3 optimization level for RISC-V builds

- Use flag_if_supported_with_fallbacks to gracefully handle unsupported flags

The optimization is automatically applied when compiling on riscv64 targets, with graceful fallback if the compiler doesn't support RVV extensions.

Tested on:

- RISC-V 64-bit platform (riscv64)

- All tests pass (32 unit tests + 1 integration test + 4 doc tests)

- Build successful with both debug and release profiles

This enables better performance for zstd compression/decompression on RISC-V platforms that support vector extensions.