### PR TITLE
Mark unsound safe wasm shims qsort and memcmp as unsafe

### DIFF
--- a/zstd-safe/zstd-sys/src/wasm_shim.rs
+++ b/zstd-safe/zstd-sys/src/wasm_shim.rs
@@ -5,7 +5,7 @@ const USIZE_ALIGN: usize = core::mem::align_of::<usize>();
 const USIZE_SIZE: usize = core::mem::size_of::<usize>();
 
 #[no_mangle]
-pub extern "C" fn rust_zstd_wasm_shim_qsort(
+pub unsafe extern "C" fn rust_zstd_wasm_shim_qsort(
     base: *mut c_void,
     n_items: usize,
     size: usize,
@@ -46,7 +46,7 @@ pub extern "C" fn rust_zstd_wasm_shim_malloc(size: usize) -> *mut c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn rust_zstd_wasm_shim_memcmp(
+pub unsafe extern "C" fn rust_zstd_wasm_shim_memcmp(
     str1: *const c_void,
     str2: *const c_void,
     n: usize,


### PR DESCRIPTION
Found during an agent-driven safety review. I assume these functions aren't _actually_ supposed to be callable from Rust, but they currently are.

This is technically a breaking change but I think anyone calling these from Rust is probably doing it wrong, unless I've misunderstood the API.