### PR TITLE
zstd-sys: auto-disable assembly on wasm targets

### DIFF
--- a/zstd-safe/zstd-sys/build.rs
+++ b/zstd-safe/zstd-sys/build.rs
@@ -138,7 +138,19 @@ fn compile_zstd() {
 
     // Either include ASM files, or disable ASM entirely.
     // Also disable it on windows, apparently it doesn't do well with these .S files at the moment.
-    if cfg!(feature = "no_asm") || std::env::var("CARGO_CFG_WINDOWS").is_ok() {
+    // Disable it on wasm as well: the only assembly zstd ships is
+    // x86-64-specific (huf_decompress_amd64.S, gated upstream on __x86_64__
+    // in portability_macros.h), so on wasm it could only ever produce an
+    // empty object — and wasm toolchains frequently cannot assemble .S
+    // input at all, which makes the default features unbuildable there for
+    // no benefit.
+    let target_arch =
+        std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let is_wasm = target_arch == "wasm32" || target_arch == "wasm64";
+    if cfg!(feature = "no_asm")
+        || std::env::var("CARGO_CFG_WINDOWS").is_ok()
+        || is_wasm
+    {
         config.define("ZSTD_DISABLE_ASM", Some(""));
     } else {
         config.file("zstd/lib/decompress/huf_decompress_amd64.S");


### PR DESCRIPTION
The only assembly zstd ships is x86-64-specific: upstream gates it on
`__x86_64__` via `ZSTD_ENABLE_ASM_X86_64_BMI2` in
`lib/common/portability_macros.h`, so on every other architecture
`huf_decompress_amd64.S` preprocesses to an empty object. On wasm32/wasm64
it can never contribute code, but build.rs still passes it to the C
toolchain unless `no_asm` is set — forcing an assembler invocation for
nothing, and hard-failing the build on wasm toolchain setups that cannot
process `.S` input at all (cc shims and wrapped/in-process clang
drivers with no external assembler stage). Because cargo features are additive and consumer-set,
`no_asm` doesn't help anyone who gets zstd-sys transitively.

Repro of the pointless assemble on a stock toolchain:

```
cargo new zc && cd zc && cargo add zstd-sys@2.0.16
cargo build --target wasm32-wasip1 -vv 2>&1 | grep huf_decompress_amd64.S
# the x86-64 .S is compiled for a wasm target; it contributes nothing
# (upstream's own ZSTD_ENABLE_ASM_X86_64_BMI2 gate makes it an empty TU)
```

build.rs already auto-defines `ZSTD_DISABLE_ASM` on Windows for the same
practical reason. This PR extends that to
`CARGO_CFG_TARGET_ARCH == wasm32/wasm64`: define `ZSTD_DISABLE_ASM`, skip
the `.S`, regardless of features. `no_asm` is unchanged everywhere else,
and on wasm the produced library is bit-identical to a `no_asm` build (the
asm was never enabled there by zstd's own preprocessor logic).

Verified on wasm32-wasip1: default-features zstd-sys 2.0.16 previously
died at the `.S`; with this change the identical build completes and an
`encode_all`/`decode_all` roundtrip passes, matching the `no_asm` result.
