### PR TITLE
Exclude bindgen from zstd-sys default features

### DIFF
--- a/zstd-safe/zstd-sys/Cargo.toml
+++ b/zstd-safe/zstd-sys/Cargo.toml
@@ -65,7 +65,7 @@ version = "1.0.45"
 features = ["parallel"]
 
 [features]
-default = ["legacy", "zdict_builder", "bindgen"]
+default = ["legacy", "zdict_builder"]
 
 debug = [] # Enable zstd debug logs
 experimental = [] # Expose experimental ZSTD API


### PR DESCRIPTION
Keep the remaining defaults (legacy, zdict_builder). bindgen stays available as an opt-in feature; pre-generated bindings are used otherwise.

bindgen makes hermetic compilation (e.g. Bazel) and cross-compilation hard, because it needs libclang at build time.

Fixes #370

AI assistance was used.