### PR TITLE
tie prepared dictionary lifetime to stream context

### DIFF
--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -164,7 +164,7 @@ impl<'a> Decoder<'a> {
 
     /// Creates a new decoder, using an existing `DecoderDictionary`.
     pub fn with_prepared_dictionary<'b>(
-        dictionary: &DecoderDictionary<'b>,
+        dictionary: &'a DecoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,
@@ -299,7 +299,7 @@ impl<'a> Encoder<'a> {
 
     /// Creates a new encoder using an existing `EncoderDictionary`.
     pub fn with_prepared_dictionary<'b>(
-        dictionary: &EncoderDictionary<'b>,
+        dictionary: &'a EncoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,

--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -73,7 +73,7 @@ impl<'a, R: BufRead> Decoder<'a, R> {
     /// The dictionary must be the same as the one used during compression.
     pub fn with_prepared_dictionary<'b>(
         reader: R,
-        dictionary: &DecoderDictionary<'b>,
+        dictionary: &'a DecoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,
@@ -184,7 +184,7 @@ impl<'a, R: BufRead> Encoder<'a, R> {
     /// The dictionary must be the same as the one used during compression.
     pub fn with_prepared_dictionary<'b>(
         reader: R,
-        dictionary: &EncoderDictionary<'b>,
+        dictionary: &'a EncoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,

--- a/src/stream/write/mod.rs
+++ b/src/stream/write/mod.rs
@@ -218,7 +218,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// but requires the dictionary to be present during decompression.)
     pub fn with_prepared_dictionary<'b>(
         writer: W,
-        dictionary: &EncoderDictionary<'b>,
+        dictionary: &'a EncoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,
@@ -385,7 +385,7 @@ impl<'a, W: Write> Decoder<'a, W> {
     /// but requires the dictionary to be present during decompression.)
     pub fn with_prepared_dictionary<'b>(
         writer: W,
-        dictionary: &DecoderDictionary<'b>,
+        dictionary: &'a DecoderDictionary<'b>,
     ) -> io::Result<Self>
     where
         'b: 'a,


### PR DESCRIPTION
**Prepared dictionaries could be freed while streams still reference them**

`ZSTD_CCtx_refCDict` and `ZSTD_DCtx_refDDict` keep a raw pointer to the prepared dictionary, so it must outlive the stream context. The stream `with_prepared_dictionary` constructors only bound the dictionary inner buffer lifetime (`'b: 'a`), not the borrow of the dictionary object, so an owned dictionary from `EncoderDictionary::copy` could be dropped right after construction and the next write dereferences the freed CDict. bulk already ties the borrow (`&'a EncoderDictionary<'b>`); the stream constructors now do the same, which makes an early drop a borrow-check error.

Fixes #365.