### PR TITLE
feat: route memory allocations through Rust's global allocator

### DIFF
--- a/src/stream/raw.rs
+++ b/src/stream/raw.rs
@@ -162,6 +162,16 @@ impl<'a> Decoder<'a> {
         }
     }
 
+    /// Creates a new decoder that takes ownership of the provided context.
+    ///
+    /// This is useful when the context was built by the caller (for example
+    /// with a custom allocator) and the decoder is moved around by value.
+    pub fn with_owned_context(context: zstd_safe::DCtx<'a>) -> Self {
+        Self {
+            context: MaybeOwnedDCtx::Owned(context),
+        }
+    }
+
     /// Creates a new decoder, using an existing `DecoderDictionary`.
     pub fn with_prepared_dictionary<'b>(
         dictionary: &DecoderDictionary<'b>,
@@ -294,6 +304,16 @@ impl<'a> Encoder<'a> {
     pub fn with_context(context: &'a mut zstd_safe::CCtx<'static>) -> Self {
         Self {
             context: MaybeOwnedCCtx::Borrowed(context),
+        }
+    }
+
+    /// Creates a new encoder that takes ownership of the provided context.
+    ///
+    /// This is useful when the context was built by the caller (for example
+    /// with a custom allocator) and the encoder is moved around by value.
+    pub fn with_owned_context(context: zstd_safe::CCtx<'a>) -> Self {
+        Self {
+            context: MaybeOwnedCCtx::Owned(context),
         }
     }
 

--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -59,6 +59,23 @@ impl<'a, R: BufRead> Decoder<'a, R> {
         }
     }
 
+    /// Creates a new decoder that owns the provided context.
+    ///
+    /// Useful when the context was built by the caller (for example with a
+    /// custom allocator) and the decoder is returned/moved by value, so a
+    /// borrowed context (`with_context`) cannot outlive it.
+    pub fn with_owned_context(
+        reader: R,
+        context: zstd_safe::DCtx<'a>,
+    ) -> Self {
+        Self {
+            reader: zio::Reader::new(
+                reader,
+                raw::Decoder::with_owned_context(context),
+            ),
+        }
+    }
+
     /// Sets this `Decoder` to stop after the first frame.
     ///
     /// By default, it keeps concatenating frames until EOF is reached.

--- a/src/stream/write/mod.rs
+++ b/src/stream/write/mod.rs
@@ -212,6 +212,19 @@ impl<'a, W: Write> Encoder<'a, W> {
         Self::with_encoder(writer, encoder)
     }
 
+    /// Creates an encoder that owns the provided context.
+    ///
+    /// Useful when the context was built by the caller (for example with a
+    /// custom allocator) and the encoder is returned/moved by value, so a
+    /// borrowed context (`with_context`) cannot outlive it.
+    pub fn with_owned_context(
+        writer: W,
+        context: zstd_safe::CCtx<'a>,
+    ) -> Self {
+        let encoder = raw::Encoder::with_owned_context(context);
+        Self::with_encoder(writer, encoder)
+    }
+
     /// Creates a new encoder, using an existing prepared `EncoderDictionary`.
     ///
     /// (Provides better compression ratio for small files,

--- a/tests/global_allocator_context.rs
+++ b/tests/global_allocator_context.rs
@@ -1,0 +1,65 @@
+//! End-to-end: streaming Encoder/Decoder owning contexts that allocate through
+//! Rust's global allocator (`CCtx::try_create_with_global_allocator` +
+//! `with_owned_context`).
+#![cfg(feature = "experimental")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::io::{BufReader, Read, Write};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+use zstd::zstd_safe::{CCtx, DCtx};
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        LIVE_BYTES.fetch_add(layout.size(), Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size(), Relaxed);
+        System.dealloc(ptr, layout)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+#[test]
+fn streaming_roundtrip_with_owned_global_allocator_contexts() {
+    let input =
+        b"the quick brown fox jumps over the lazy dog; ".repeat(10_000);
+
+    let cctx = CCtx::try_create_with_global_allocator()
+        .expect("failed to create CCtx");
+    let live_with_cctx = LIVE_BYTES.load(Relaxed);
+
+    let compressed = {
+        let mut encoder = zstd::Encoder::with_owned_context(Vec::new(), cctx);
+        encoder.write_all(&input).expect("compression failed");
+        // The streaming workspace is allocated lazily on first write; by now
+        // it must be visible to the global allocator (~1 MiB at the default
+        // level).
+        assert!(
+            LIVE_BYTES.load(Relaxed) > live_with_cctx + 512 * 1024,
+            "the encoder workspace is not visible to the global allocator"
+        );
+        encoder.finish().expect("failed to finish frame")
+    };
+
+    let dctx = DCtx::try_create_with_global_allocator()
+        .expect("failed to create DCtx");
+    let mut decoder = zstd::Decoder::with_owned_context(
+        BufReader::new(compressed.as_slice()),
+        dctx,
+    );
+    let mut roundtrip = Vec::with_capacity(input.len());
+    decoder
+        .read_to_end(&mut roundtrip)
+        .expect("decompression failed");
+
+    assert_eq!(input, roundtrip, "roundtrip mismatch");
+}

--- a/zstd-safe/src/lib.rs
+++ b/zstd-safe/src/lib.rs
@@ -27,6 +27,9 @@ extern crate std;
 #[cfg(test)]
 mod tests;
 
+#[cfg(feature = "experimental")]
+mod rust_allocator;
+
 #[cfg(feature = "seekable")]
 pub mod seekable;
 
@@ -252,6 +255,26 @@ impl<'a> CCtx<'a> {
     pub fn create() -> Self {
         Self::try_create()
             .expect("zstd returned null pointer when creating new context")
+    }
+
+    /// Tries to create a new context whose internal allocations go through
+    /// Rust's global allocator instead of the C runtime's `malloc`.
+    ///
+    /// Returns `None` if zstd returns a NULL pointer - may happen if
+    /// allocation fails.
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "experimental")))]
+    pub fn try_create_with_global_allocator() -> Option<Self> {
+        // Safety: Just FFI. The customMem callbacks uphold the malloc/free
+        // contract (see `rust_allocator`).
+        Some(CCtx(
+            NonNull::new(unsafe {
+                zstd_sys::ZSTD_createCCtx_advanced(
+                    crate::rust_allocator::RUST_GLOBAL_ALLOCATOR,
+                )
+            })?,
+            PhantomData,
+        ))
     }
 
     /// Wraps the `ZSTD_compressCCtx()` function
@@ -918,6 +941,25 @@ impl<'a> DCtx<'a> {
     pub fn create() -> Self {
         Self::try_create()
             .expect("zstd returned null pointer when creating new context")
+    }
+
+    /// Tries to create a new decompression context whose internal allocations
+    /// go through Rust's global allocator instead of the C runtime's `malloc`.
+    ///
+    /// Returns `None` if the operation failed
+    #[cfg(feature = "experimental")]
+    #[cfg_attr(feature = "doc-cfg", doc(cfg(feature = "experimental")))]
+    pub fn try_create_with_global_allocator() -> Option<Self> {
+        // Safety: Just FFI. The customMem callbacks uphold the malloc/free
+        // contract (see `rust_allocator`).
+        Some(DCtx(
+            NonNull::new(unsafe {
+                zstd_sys::ZSTD_createDCtx_advanced(
+                    crate::rust_allocator::RUST_GLOBAL_ALLOCATOR,
+                )
+            })?,
+            PhantomData,
+        ))
     }
 
     /// Fully decompress the given frame.

--- a/zstd-safe/src/rust_allocator.rs
+++ b/zstd-safe/src/rust_allocator.rs
@@ -1,0 +1,70 @@
+//! A `ZSTD_customMem` backed by Rust's global allocator.
+//!
+//! By default, zstd allocates its internal state (e.g. per-context compression
+//! windows and match-finder tables, easily megabytes per context) with the C
+//! runtime's `malloc`/`free`, invisible to Rust. Creating contexts with this
+//! `ZSTD_customMem` routes those allocations through the Rust global allocator
+//! instead, so custom `#[global_allocator]` implementations (tracking,
+//! counting, jemalloc, ...) see them too.
+//!
+//! `ZSTD_customMem` is specified as a drop-in replacement for `malloc`/`free`:
+//! zstd frees every allocation through the same `customFree` it allocated it
+//! with, passes NULL to `customFree` freely, and relies on its own internal
+//! re-alignment (`ZSTD_cwksp`) for anything stricter than `malloc` alignment.
+//!
+//! Rust's `dealloc` requires the original `Layout`, which `customFree` is not
+//! given, so the allocation size is stored in a header just below the pointer
+//! handed to zstd. This mirrors the `malloc` shim zstd-sys already uses on
+//! wasm targets (`zstd-sys/src/wasm_shim.rs`), with a 16-byte header so the
+//! returned pointer keeps the fundamental (`max_align_t`) alignment `malloc`
+//! guarantees on 64-bit platforms.
+
+extern crate alloc;
+
+use alloc::alloc::{alloc, dealloc, Layout};
+use core::ffi::c_void;
+use core::ptr;
+
+/// Size (and alignment) of the header stored below each allocation, holding
+/// the full allocation size so the `Layout` can be rebuilt on free.
+const HEADER: usize = 16;
+
+unsafe extern "C" fn rust_alloc(
+    _opaque: *mut c_void,
+    size: usize,
+) -> *mut c_void {
+    let Some(total) = size.checked_add(HEADER) else {
+        return ptr::null_mut();
+    };
+    // Safety: `total` is non-zero, does not overflow, and HEADER is a power
+    // of two, so the layout is valid.
+    let layout = Layout::from_size_align_unchecked(total, HEADER);
+    let base = alloc(layout);
+    if base.is_null() {
+        // zstd surfaces NULL as a memory_allocation error; never unwind
+        // through the FFI boundary.
+        return ptr::null_mut();
+    }
+    base.cast::<usize>().write(total);
+    base.add(HEADER).cast()
+}
+
+unsafe extern "C" fn rust_free(_opaque: *mut c_void, address: *mut c_void) {
+    // ZSTD_customFree may be called with NULL.
+    if address.is_null() {
+        return;
+    }
+    // Safety: zstd only frees pointers returned by `rust_alloc`, which wrote
+    // the allocation size right below the returned pointer.
+    let base = address.cast::<u8>().sub(HEADER);
+    let total = base.cast::<usize>().read();
+    dealloc(base, Layout::from_size_align_unchecked(total, HEADER));
+}
+
+/// Allocator table passed to `ZSTD_create*_advanced()`.
+pub(crate) const RUST_GLOBAL_ALLOCATOR: zstd_sys::ZSTD_customMem =
+    zstd_sys::ZSTD_customMem {
+        customAlloc: Some(rust_alloc),
+        customFree: Some(rust_free),
+        opaque: ptr::null_mut(),
+    };

--- a/zstd-safe/tests/global_allocator.rs
+++ b/zstd-safe/tests/global_allocator.rs
@@ -1,0 +1,87 @@
+//! Contexts created with `try_create_with_global_allocator` must route zstd's
+//! internal allocations through Rust's global allocator, and free everything
+//! through it on drop.
+#![cfg(all(feature = "experimental", feature = "std"))]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+
+use zstd_safe::{CCtx, DCtx};
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static TOTAL_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        LIVE_BYTES.fetch_add(layout.size(), Relaxed);
+        TOTAL_ALLOCS.fetch_add(1, Relaxed);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size(), Relaxed);
+        System.dealloc(ptr, layout)
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+#[test]
+fn context_allocations_go_through_global_allocator() {
+    let input = b"hello zstd hello zstd hello zstd".repeat(256);
+    // Pre-allocate the buffers so only the contexts allocate between the
+    // measurement points below.
+    let mut compressed =
+        Vec::with_capacity(zstd_safe::compress_bound(input.len()));
+    let mut decompressed = Vec::with_capacity(input.len());
+
+    // --- compression context ---
+    let live_before = LIVE_BYTES.load(Relaxed);
+    let allocs_before = TOTAL_ALLOCS.load(Relaxed);
+    {
+        let mut cctx = CCtx::try_create_with_global_allocator()
+            .expect("failed to create CCtx");
+        cctx.compress(&mut compressed, &input, 3)
+            .expect("compression failed");
+
+        let held = LIVE_BYTES.load(Relaxed) - live_before;
+        assert!(
+            TOTAL_ALLOCS.load(Relaxed) > allocs_before,
+            "the CCtx never hit the global allocator"
+        );
+        assert!(
+            held > 1024,
+            "expected the CCtx workspace to be held via the global \
+             allocator, only {held} bytes live"
+        );
+    }
+    // Dropping the context must return every byte through the same allocator.
+    assert_eq!(
+        LIVE_BYTES.load(Relaxed),
+        live_before,
+        "CCtx leaked global-allocator memory"
+    );
+
+    // --- decompression context ---
+    let live_before = LIVE_BYTES.load(Relaxed);
+    {
+        let mut dctx = DCtx::try_create_with_global_allocator()
+            .expect("failed to create DCtx");
+        dctx.decompress(&mut decompressed, &compressed)
+            .expect("decompression failed");
+        assert!(
+            LIVE_BYTES.load(Relaxed) > live_before,
+            "the DCtx never hit the global allocator"
+        );
+    }
+    assert_eq!(
+        LIVE_BYTES.load(Relaxed),
+        live_before,
+        "DCtx leaked global-allocator memory"
+    );
+
+    assert_eq!(input, decompressed, "roundtrip mismatch");
+}


### PR DESCRIPTION
Let applications opt in to having all of zstd's internal memory - context structs, per-context compression windows, match-finder tables, stream buffers - allocated through Rust's global allocator instead of the C runtime's malloc.