### PR TITLE
Reduce buffer growth and initialization overhead in read_to_end

### DIFF
--- a/src/stream/read/mod.rs
+++ b/src/stream/read/mod.rs
@@ -154,6 +154,10 @@ impl<R: BufRead> Read for Decoder<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.reader.read(buf)
     }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.reader.read_to_end(buf)
+    }
 }
 
 impl<R: Read> Encoder<'static, BufReader<R>> {

--- a/src/stream/zio/reader.rs
+++ b/src/stream/zio/reader.rs
@@ -168,6 +168,43 @@ where
     R: BufRead,
     D: Operation,
 {
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        let start = buf.len();
+        let mut written = start;
+        loop {
+            let result = if written == buf.capacity() {
+                // Check for EOF before growing a full (or empty) vector.
+                let mut probe = [0; 32];
+                self.read(&mut probe).map(|n| {
+                    buf.extend_from_slice(&probe[..n]);
+                    n
+                })
+            } else {
+                // Initialize only one block of spare capacity at a time.
+                // Keep it initialized across short reads so we don't repeatedly
+                // zero the same space. Bounded slices retain streaming behavior.
+                if written == buf.len() {
+                    let chunk = (buf.capacity() - written)
+                        .min(zstd_safe::BLOCKSIZE_MAX as usize);
+                    buf.resize(written + chunk, 0);
+                }
+                self.read(&mut buf[written..])
+            };
+            match result {
+                Ok(0) => {
+                    buf.truncate(written);
+                    return Ok(written - start);
+                }
+                Ok(n) => written += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => {
+                    buf.truncate(written);
+                    return Err(e);
+                }
+            }
+        }
+    }
+
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         // `Read::read` is specified to return `Ok(0)` for an empty buffer.
         // Without this, the loop below would keep asking the operation to write
@@ -287,6 +324,22 @@ mod tests {
             reader.read_to_end(&mut output).unwrap();
         }
         assert_eq!(&output, input);
+    }
+
+    #[test]
+    fn test_noop_read_to_end_appends_across_chunks() {
+        use crate::stream::raw::NoOp;
+
+        let input = vec![42; zstd_safe::BLOCKSIZE_MAX as usize + 17];
+        for spare in [0, 1, input.len(), input.len() + 1] {
+            let mut output = Vec::with_capacity(6 + spare);
+            output.extend_from_slice(b"prefix");
+            let mut reader = Reader::new(&input[..], NoOp);
+            assert_eq!(reader.read_to_end(&mut output).unwrap(), input.len());
+            assert_eq!(&output[..6], b"prefix");
+            assert_eq!(&output[6..], input);
+            assert_eq!(reader.read_to_end(&mut output).unwrap(), 0);
+        }
     }
 
     #[test]


### PR DESCRIPTION
I keep coming back to this crate in many of my new projects, so I thought it would be nice to contribute with a small optimization.

This PR specializes `Decoder::read_to_end` to probe for EOF before growing a full output vector. Initialize spare capacity in chunks of at most 128 KiB and reuse initialized space across short reads. This avoids unnecessary EOF reallocations without adding unsafe code.

Add a regression test covering appended output, block boundaries, varying spare capacity, and repeated EOF.

## Benchmarks
Benchmarked on **Windows**, using an **Intel Xeon E5-2696 v4** and **Rust 1.98.0**. Timings are medians of seven alternating before/after batches.

"Recorded size" indicates whether the frame includes its decompressed size. Positive cycle savings mean fewer CPU cycles; negative values indicate a regression.

| Input | Decoded size | Recorded size | Before (µs) | After (µs) | Throughput (MiB/s), before → after | CPU cycles saved |
|:------|------------:|:-------------:|------------:|-----------:|---------------------------------:|-----------------:|
| Text   | 1 KiB       | No  | 5.92      | 5.74     | 165 → 170     | 3.0% |
| Text   | 1 KiB       | Yes | 4.82      | 4.89     | 203 → 200     | **−1.6%** |
| Random | 1 KiB       | No  | 2.40      | 2.30     | 406 → 424     | 4.3% |
| Random | 1 KiB       | Yes | 0.98      | 1.00     | 999 → 974     | **−2.6%** |
| Text   | 64 KiB      | No  | 23.45     | 20.70    | 2,665 → 3,019 | 11.7% |
| Text   | 64 KiB      | Yes | 12.81     | 9.72     | 4,877 → 6,432 | 24.1% |
| Random | 64 KiB      | No  | 27.10     | 23.01    | 2,306 → 2,717 | 15.2% |
| Random | 64 KiB      | Yes | 13.02     | 9.38     | 4,801 → 6,661 | 27.9% |
| Text   | 1,000,000 B | No  | 567.92    | 554.84   | 1,679 → 1,719 | 2.3% |
| Text   | 1,000,000 B | Yes | 200.76    | 177.77   | 4,750 → 5,365 | 10.9% |
| Random | 1,000,000 B | No  | 678.73    | 656.79   | 1,405 → 1,452 | 3.1% |
| Random | 1,000,000 B | Yes | 313.40    | 274.07   | 3,043 → 3,480 | 12.6% |
| Text   | 1 MiB       | No  | 1,188.60  | 578.99   | 841 → 1,727   | **51.1%** |
| Text   | 1 MiB       | Yes | 532.72    | 508.30   | 1,877 → 1,967 | 4.7% |
| Random | 1 MiB       | No  | 1,247.12  | 708.64   | 802 → 1,411   | 43.2% |
| Random | 1 MiB       | Yes | 690.23    | 636.89   | 1,449 → 1,570 | 7.7% |
| Text   | 8 MiB       | No  | 11,130.45 | 6,489.21 | 719 → 1,233   | 41.6% |
| Text   | 8 MiB       | Yes | 3,909.97  | 3,644.08 | 2,046 → 2,195 | 7.0% |
| Random | 8 MiB       | No  | 11,476.45 | 7,850.15 | 697 → 1,019   | 31.6% |
| Random | 8 MiB       | Yes | 5,350.49  | 4,867.31 | 1,495 → 1,644 | 9.0% |

**Output capacity and reallocations**

For frames without a recorded size, text and random inputs produced the same results:

| Decoded size | Capacity before | Capacity after | Reallocations before | Reallocations after |
|------------:|----------------:|---------------:|---------------------:|--------------------:|
| 1 KiB       | 2 KiB   | 1 KiB  | 6  | 5  |
| 64 KiB      | 128 KiB | 64 KiB | 12 | 11 |
| 1,000,000 B | 1 MiB   | 1 MiB  | 15 | 15 |
| 1 MiB       | 2 MiB   | 1 MiB  | 16 | 15 |
| 8 MiB       | 16 MiB  | 8 MiB  | 19 | 18 |

Known-size cases retained the same output capacity and required zero output reallocations in both implementations. Warmed buffer/context reuse preserved zero Rust allocation churn.

## Testing and linting
- Tests passed with default features, no default features, `experimental,zstdmt`, and `thin`.
- Clippy passed with warnings denied.
- Both NoOp reader tests passed under Miri.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.